### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ZanadirScan.yml
+++ b/.github/workflows/ZanadirScan.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   zanadir-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/8](https://github.com/MustacheCase/zanadir/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
1. The `actions/checkout@v4` action requires `contents: read` to fetch the repository's code.
2. The `mustachecase/zanadir-action@v1.2` action does not appear to require write permissions based on the provided configuration.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` is scoped appropriately for the entire workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
