### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Vulnerability_Scan.yml
+++ b/.github/workflows/Vulnerability_Scan.yml
@@ -11,6 +11,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Restrict permissions for the GITHUB_TOKEN
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/7](https://github.com/MustacheCase/zanadir/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read operations (e.g., scanning the project), the `contents: read` permission is sufficient. This will restrict the `GITHUB_TOKEN` to read-only access to repository contents, minimizing the risk of misuse.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `vulnerability-scan` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
