### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/TestAndBuild.yml
+++ b/.github/workflows/TestAndBuild.yml
@@ -9,6 +9,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Limit permissions for the workflow
+permissions:
+  contents: read
+  pull-requests: write
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "test-and-build"


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/6](https://github.com/MustacheCase/zanadir/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow:
- `contents: read` is required for checking out the repository and running tests.
- `pull-requests: write` may be required if the workflow interacts with pull requests (e.g., updating statuses).
- Additional permissions (e.g., `actions: write`) may be required for uploading coverage reports or other specific tasks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `test-and-build` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
