### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CRobot.yml
+++ b/.github/workflows/CRobot.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:                                     
     types: [created, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/2](https://github.com/MustacheCase/zanadir/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the provided code, the workflow primarily reads repository contents and interacts with pull requests. Therefore, the permissions can be set to `contents: read` and `pull-requests: write`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`review`) in the workflow. This ensures that the `GITHUB_TOKEN` has restricted access throughout the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
