### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/DockerhubPublish.yml
+++ b/.github/workflows/DockerhubPublish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/3](https://github.com/MustacheCase/zanadir/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily needs `contents: read` to check out the code and possibly no additional permissions for other steps. If any step requires write permissions (e.g., for pull requests or issues), those can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
