### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/LicenseCompliance.yml
+++ b/.github/workflows/LicenseCompliance.yml
@@ -1,4 +1,6 @@
 name: License Compliance Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/5](https://github.com/MustacheCase/zanadir/security/code-scanning/5)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, ensuring that the `GITHUB_TOKEN` operates with the least privilege necessary. Based on the workflow's functionality, the `contents: read` permission is sufficient for checking out code and performing the license compliance scan. No write permissions are required.

The `permissions` block should be added immediately after the `name` field at the top of the file. This will apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
