### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/SecretsScan.yml
+++ b/.github/workflows/SecretsScan.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   secrets-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/4](https://github.com/MustacheCase/zanadir/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow involves checking out code and running a secret scanning tool, it only requires `contents: read` permissions. This change ensures the workflow operates with the minimum necessary privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
