### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/EOLScan.yml
+++ b/.github/workflows/EOLScan.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   eol-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MustacheCase/zanadir/security/code-scanning/1](https://github.com/MustacheCase/zanadir/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out code and scans the project, it likely requires only read access to the repository contents. We will add the `permissions` key at the root level of the workflow to apply the least privilege permissions (`contents: read`) to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
