### PR TITLE
chore: upgrade Go from 1.24 to 1.26.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment:**
  - OS: [e.g. macOS, Linux, Windows]
- - Go version: [e.g. 1.24]
+ - Go version: [e.g. 1.26]
  - Zanadir version: [e.g. 1.0.0]
 
 **Additional context**

--- a/.github/workflows/DependencyUpdate.yml
+++ b/.github/workflows/DependencyUpdate.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '1.26'
 
       - name: Update dependencies
         run: |

--- a/.github/workflows/TestAndBuild.yml
+++ b/.github/workflows/TestAndBuild.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - name: Lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout=5m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Zanadir! This document provides g
 
 ## Prerequisites
 
-- Go 1.24 or later
+- Go 1.26 or later
 - Git
 - Basic understanding of Go programming language
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - Build binary and get CA certs
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ lint:
 
 # Install golangci-lint if not present
 install-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2 
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MustacheCase/zanadir
 
-go 1.24.6
+go 1.26.6
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5


### PR DESCRIPTION
# Pull Request

## Description

Upgrades the Go toolchain from 1.24 to **1.26.6**, the latest stable release, across every place the version is pinned:

| File | Change |
|---|---|
| `go.mod` | `go 1.24.6` → `go 1.26.6` |
| `Dockerfile` | `golang:1.24-alpine` → `golang:1.26-alpine` |
| `.github/workflows/TestAndBuild.yml` | `go-version: '1.24'` → `'1.26'` |
| `.github/workflows/DependencyUpdate.yml` | `go-version: '>=1.21'` → `'1.26'` |
| `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/bug_report.md` | docs bumped to 1.26 |

### Lint tooling bumped alongside

Two changes are included because the Go upgrade breaks the existing lint setup:

- **`Makefile`** — pinned golangci-lint `v1.55.2` → `v2.12.2`. The v1.55 line predates Go 1.26 and cannot parse the source at all.
- **`TestAndBuild.yml`** — `golangci-lint-action@v5` → `@v9`. The workflow uses `version: latest`, which now resolves to golangci-lint v2.x, and the v5 action does not support the v2 binary.

## Type of change

- [x] Other: build/toolchain maintenance

## How Has This Been Tested?

Verified locally against go1.26.6 (darwin/arm64):

```bash
go mod tidy      # no changes — dependencies already compatible
go build -o zanadir .
go vet ./...
go test -race ./...
./zanadir scan --dir .
```

All packages pass under `-race`, and the built binary produces correct scan output against this repo.

## Notes for reviewers

- The `go` directive uses a full patch version (`1.26.6`), matching the previous `1.24.6` convention. Contributors on an older toolchain will auto-download 1.26.6 via `GOTOOLCHAIN=auto`.
- `go.sum` is untouched — no dependency changes were required.
- **golangci-lint v2 was not verified locally** (not installed on the dev machine). The repo has no `.golangci.yml`, so v2 falls back to its own defaults, which differ from v1's. The first CI run may surface new lint findings unrelated to this bump; happy to add a `.golangci.yml` pinning the previous rule set if that's preferred.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, no logic changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`go vet` clean)
- [ ] I have added tests — n/a, toolchain bump with no behavior change
- [x] New and existing unit tests pass locally with my changes
