### PR TITLE
chore: fix install-lint target for Go 1.26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment:**
  - OS: [e.g. macOS, Linux, Windows]
- - Go version: [e.g. 1.24]
+ - Go version: [e.g. 1.26]
  - Zanadir version: [e.g. 1.0.0]
 
 **Additional context**

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ lint:
 
 # Install golangci-lint if not present
 install-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.0 
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to the Go 1.26 upgrade (#125, #127). The `install-lint` Makefile target still pins **golangci-lint v1.59.0**, which cannot lint this module on Go 1.26 — it fails during typechecking on every package that imports an internal package:

```
rules/rules.go:7:2: could not import github.com/MustacheCase/zanadir/models
  (-: could not load export data: internal error in importing
  "github.com/MustacheCase/zanadir/models" (unsupported version: 2)) (typecheck)
```

CI is unaffected, because `golangci-lint-action@v8` installs its own v2.x and ignores the Makefile entirely — which is likely why this went unnoticed. The breakage only hits contributors running `make install-lint && make lint` locally.

This switches the target to `go install` of **golangci-lint v2.12.2**, which reports `0 issues` on the current tree.

### Why `go install` rather than re-pointing the curl script at v2

Two independent problems with the existing installer, both fixed by dropping it:

1. **The legacy `install.sh` cannot install v2 at all.** v2 releases ship `.sbom.json` artifacts alongside each tarball, and the script's prefix match picks up the SBOM's checksum instead of the tarball's, so it aborts:

   ```
   hash_sha256_verify checksum for '...golangci-lint-2.12.2-darwin-arm64.tar.gz' did not verify
   c8debe3b... vs a9c54498...
   ```

   To be clear, this is a script bug, not a supply-chain issue — `a9c54498...` is the tarball's genuine published checksum, and `c8debe3b...` belongs to `golangci-lint-2.12.2-darwin-arm64.tar.gz.sbom.json`. Both were verified against the official `checksums.txt`.

2. **`$(go env GOPATH)` was expanded by make, not the shell.** Make treats it as an undefined variable and substitutes an empty string, so the recipe actually ran `-b /bin`:

   ```console
   $ make -n install-lint
   curl -sSfL ... | sh -s -- -b /bin v1.59.0
   ```

   It needed `$$(go env GOPATH)` to reach the shell. `go install` honours `GOBIN`/`GOPATH` natively, so the interpolation goes away.

Also updates the Go version reference in the bug report template, missed when the toolchain moved to 1.26.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On go1.26.6 (darwin/arm64):

```bash
# reproduce the failure
curl -sSfL .../install.sh | sh -s -- -b /tmp/lintv1 v1.59.0
/tmp/lintv1/golangci-lint run ./...   # typecheck errors, as above

# verify the fix
go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
golangci-lint run ./...               # 0 issues

make -n install-lint                  # expands correctly now
go build ./... && go vet ./... && go test -race ./...   # all pass
```

## Notes for reviewers

- The repo has no `.golangci.yml`, so v2 runs its default linter set. That default set is clean on the current tree (`0 issues`), so no config file is needed — though adding one would pin the rule set against future default changes.
- `golangci-lint-action@v8` in `TestAndBuild.yml` is left alone; it already resolves to v2.x and works.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, build tooling only
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests — n/a, no application code changed
- [x] New and existing unit tests pass locally with my changes
