### PR TITLE
fix: suggest Secrets Detection and License Compliance again

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,18 @@ Future work will include support for:
 
 ## Categories We Suggest
 
-Zanadir analyzes repositories in the following categories:
+Zanadir analyzes repositories in the following categories. The name in bold is
+the exact value to pass to `--excluded-categories` (matching is
+case-insensitive):
 
 - 🛡️ **SCA**: Software Composition Analysis
-- 🔐 **Secrets**: Secrets Management
-- 📜 **Licenses**: License Compliance
-- 🛠️ **EndOfLife**: End-of-Life Software Packages
+- 🔐 **Secrets Detection**: Secrets Management
+- 📜 **License Compliance**: License Compliance
+- 🛠️ **End Of Life**: End-of-Life Software Packages
 - 📊 **Coverage**: Test Coverage
 - 📊 **Performance Testing**: Test Performance and Reliability
 - 🧑‍💻 **Linter**: Code Linting
+- 🧪 **Unit Tests**: Automated Unit Testing
 
 ## Usage Examples
 
@@ -103,8 +106,11 @@ zanadir scan --dir . --output json
 Skip certain categories during analysis:
 
 ```sh
-zanadir scan --dir . --excluded-categories "SCA,Secrets"
+zanadir scan --dir . --excluded-categories "SCA,Secrets Detection"
 ```
+
+Category names must match the list above. An unrecognized name is rejected with
+an error rather than being silently ignored.
 
 #### Enforce Mode
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/MustacheCase/zanadir/models"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +21,19 @@ type Config struct {
 	Enforce            bool
 	Debug              bool
 	Output             string
+}
+
+// normalizeCategories canonicalises category names and rejects unknown ones.
+func normalizeCategories(categories []string) ([]string, error) {
+	normalized := make([]string, 0, len(categories))
+	for _, c := range categories {
+		title, ok := models.ResolveCategory(c)
+		if !ok {
+			return nil, fmt.Errorf("unknown category %q: valid categories are %s", c, strings.Join(models.CategoryNames(), ", "))
+		}
+		normalized = append(normalized, string(title))
+	}
+	return normalized, nil
 }
 
 func CreateConfig(cmd *cobra.Command) (*Config, error) {
@@ -40,6 +55,11 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 	}
 
 	excludedCategories, _ := cmd.Flags().GetStringSlice("excluded-categories")
+	excludedCategories, err = normalizeCategories(excludedCategories)
+	if err != nil {
+		return nil, err
+	}
+
 	enforce, _ := cmd.Flags().GetBool("enforce")
 	debug, _ := cmd.Flags().GetBool("debug")
 	output, _ := cmd.Flags().GetString("output")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,8 +37,14 @@ func TestCreateConfig(t *testing.T) {
 		{
 			name:               "Excluded categories",
 			dir:                "/tmp/testdir",
-			excludedCategories: []string{"cat1", "cat2"},
+			excludedCategories: []string{"SCA", "Linter"},
 			expectError:        false,
+		},
+		{
+			name:               "Unknown excluded category",
+			dir:                "/tmp/testdir",
+			excludedCategories: []string{"cat1"},
+			expectError:        true,
 		},
 	}
 
@@ -81,4 +87,59 @@ func TestCreateConfig(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, config)
 	})
+}
+
+func newScanCmd(dir string, excluded []string) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dir", dir, "directory")
+	cmd.Flags().StringSlice("excluded-categories", excluded, "excluded categories")
+	cmd.Flags().Bool("enforce", false, "enforce")
+	cmd.Flags().Bool("debug", false, "debug")
+	cmd.Flags().String("output", OutputTable, "output")
+	return cmd
+}
+
+func TestNormalizeCategories(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+		wantErr  bool
+	}{
+		{name: "empty", input: nil, expected: []string{}},
+		{name: "canonical name", input: []string{"Secrets Detection"}, expected: []string{"Secrets Detection"}},
+		{name: "case insensitive", input: []string{"secrets detection"}, expected: []string{"Secrets Detection"}},
+		{name: "surrounding whitespace", input: []string{" SCA "}, expected: []string{"SCA"}},
+		{name: "multiple", input: []string{"SCA", "Linter"}, expected: []string{"SCA", "Linter"}},
+		// "Secrets" is the old id, not a category title.
+		{name: "stale short name is rejected", input: []string{"Secrets"}, wantErr: true},
+		{name: "typo is rejected", input: []string{"Lintr"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeCategories(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCreateConfigRejectsUnknownCategory(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := CreateConfig(newScanCmd(dir, []string{"NotACategory"}))
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "unknown category")
+}
+
+func TestCreateConfigNormalizesExcludedCategories(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := CreateConfig(newScanCmd(dir, []string{"sca"}))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"SCA"}, cfg.ExcludedCategories)
 }

--- a/models/categories.go
+++ b/models/categories.go
@@ -1,5 +1,7 @@
 package models
 
+import "strings"
+
 const (
 	SCA                CategoryTitle = "SCA"
 	Secrets            CategoryTitle = "Secrets Detection"
@@ -18,3 +20,26 @@ var CategoryTitles = []CategoryTitle{SCA, Secrets, Licenses, EndOfLife, Coverage
 type CategoryTitle string
 
 type Format string
+
+// ResolveCategory returns the canonical CategoryTitle for a user-supplied name,
+// matching case-insensitively. Callers that accept category names must resolve
+// them here rather than comparing strings themselves, so an unrecognised name
+// can be rejected instead of silently matching nothing.
+func ResolveCategory(name string) (CategoryTitle, bool) {
+	name = strings.TrimSpace(name)
+	for _, title := range CategoryTitles {
+		if strings.EqualFold(name, string(title)) {
+			return title, true
+		}
+	}
+	return "", false
+}
+
+// CategoryNames returns every valid category name, for error messages.
+func CategoryNames() []string {
+	names := make([]string, 0, len(CategoryTitles))
+	for _, title := range CategoryTitles {
+		names = append(names, string(title))
+	}
+	return names
+}

--- a/models/categories_test.go
+++ b/models/categories_test.go
@@ -1,0 +1,49 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/MustacheCase/zanadir/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected models.CategoryTitle
+		ok       bool
+	}{
+		{name: "canonical", input: "Secrets Detection", expected: models.Secrets, ok: true},
+		{name: "lowercase", input: "secrets detection", expected: models.Secrets, ok: true},
+		{name: "whitespace", input: "  SCA  ", expected: models.SCA, ok: true},
+		{name: "stale id", input: "Secrets", ok: false},
+		{name: "typo", input: "Lintr", ok: false},
+		{name: "empty", input: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := models.ResolveCategory(tt.input)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestResolveCategoryAcceptsEveryTitle(t *testing.T) {
+	for _, title := range models.CategoryTitles {
+		got, ok := models.ResolveCategory(string(title))
+		assert.True(t, ok, "%q should resolve", title)
+		assert.Equal(t, title, got)
+	}
+}
+
+func TestCategoryNamesMatchesTitles(t *testing.T) {
+	assert.Len(t, models.CategoryNames(), len(models.CategoryTitles))
+	for i, title := range models.CategoryTitles {
+		assert.Equal(t, string(title), models.CategoryNames()[i])
+	}
+}

--- a/suggester/suggester.go
+++ b/suggester/suggester.go
@@ -2,6 +2,8 @@ package suggester
 
 import (
 	"embed"
+	"fmt"
+	"strings"
 
 	"github.com/MustacheCase/zanadir/matcher"
 	"github.com/MustacheCase/zanadir/models"
@@ -107,12 +109,34 @@ func convertSuggestions(sugs []*Suggestion) []*Suggestion {
 	return result
 }
 
+// validateCategoriesMap ensures every category title resolves to a suggestions entry.
+func validateCategoriesMap(categoriesMap map[string]*CategorySuggestion) error {
+	var missing []string
+	for _, title := range models.CategoryTitles {
+		if _, ok := categoriesMap[string(title)]; !ok {
+			missing = append(missing, string(title))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("suggestions.yaml is missing an entry for category %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// newService builds a validated service from a catalogue, so the validation can
+// be exercised with a catalogue the embedded one can never produce.
+func newService(cats []CategorySuggestion) (*service, error) {
+	s := &service{CategoriesMap: buildCategoriesMap(cats)}
+	if err := validateCategoriesMap(s.CategoriesMap); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 func NewSuggestionService() (Suggester, error) {
-	s := &service{}
 	cats, err := readEmbeddedSuggestions()
 	if err != nil {
 		return nil, err
 	}
-	s.CategoriesMap = buildCategoriesMap(cats)
-	return s, nil
+	return newService(cats)
 }

--- a/suggester/suggester_test.go
+++ b/suggester/suggester_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/MustacheCase/zanadir/matcher"
+	"github.com/MustacheCase/zanadir/models"
 	"github.com/MustacheCase/zanadir/suggester"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,4 +37,40 @@ func TestFindSuggestionsWithExclusion(t *testing.T) {
 	for _, cat := range result {
 		assert.NotEqual(t, "Secrets", cat.ID)
 	}
+}
+
+// Regression test: a suggestions.yaml id that does not match its CategoryTitle
+// silently drops the category from every scan.
+func TestFindSuggestionsCoversEveryCategory(t *testing.T) {
+	s, err := suggester.NewSuggestionService()
+	assert.NoError(t, err)
+
+	result := s.FindSuggestions(nil, nil)
+
+	got := make(map[string]bool, len(result))
+	for _, cat := range result {
+		got[cat.ID] = true
+	}
+
+	assert.Len(t, result, len(models.CategoryTitles))
+	for _, title := range models.CategoryTitles {
+		assert.True(t, got[string(title)], "category %q was never suggested", title)
+	}
+}
+
+func TestFindSuggestionsExcludesByCanonicalTitle(t *testing.T) {
+	s, err := suggester.NewSuggestionService()
+	assert.NoError(t, err)
+
+	result := s.FindSuggestions(nil, []string{string(models.Secrets)})
+
+	for _, cat := range result {
+		assert.NotEqual(t, string(models.Secrets), cat.ID)
+	}
+	assert.Len(t, result, len(models.CategoryTitles)-1)
+}
+
+func TestSuggestionServiceValidatesCategories(t *testing.T) {
+	_, err := suggester.NewSuggestionService()
+	assert.NoError(t, err, "every models.CategoryTitle must exist in suggestions.yaml")
 }

--- a/suggester/suggestions.yaml
+++ b/suggester/suggestions.yaml
@@ -16,7 +16,7 @@ categories:
         description: "A developer-first security tool that finds and automatically fixes vulnerabilities in dependencies."
 
         
-  - id: "Secrets"
+  - id: "Secrets Detection"
     name: "Data Leakage & Secrets Detection"
     description: "Tools that help detect sensitive information such as secrets, API keys, and credentials in source code and configurations."
     suggestions:
@@ -36,7 +36,7 @@ categories:
         repository: "https://github.com/Yelp/detect-secrets"
         description: "An enterprise-friendly tool to detect secrets in source code using pre-commit hooks."
 
-  - id: "Licenses"
+  - id: "License Compliance"
     name: "License Compliance Tools"
     description: "Tools for checking open-source license compliance and ensuring proper usage of dependencies"
     suggestions:

--- a/suggester/validate_test.go
+++ b/suggester/validate_test.go
@@ -1,0 +1,61 @@
+package suggester
+
+import (
+	"testing"
+
+	"github.com/MustacheCase/zanadir/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// fullCatalogue returns one entry per known category, which is what a valid
+// suggestions.yaml provides.
+func fullCatalogue() []CategorySuggestion {
+	cats := make([]CategorySuggestion, 0, len(models.CategoryTitles))
+	for _, title := range models.CategoryTitles {
+		cats = append(cats, CategorySuggestion{ID: string(title), Name: string(title)})
+	}
+	return cats
+}
+
+func TestValidateCategoriesMapAcceptsFullCatalogue(t *testing.T) {
+	assert.NoError(t, validateCategoriesMap(buildCategoriesMap(fullCatalogue())))
+}
+
+// The embedded catalogue is always valid, so the failure path is only
+// reachable by constructing a catalogue that is missing an entry. This is the
+// exact shape of the bug the validation exists to catch: an id that does not
+// match its CategoryTitle.
+func TestValidateCategoriesMapReportsMissingCategory(t *testing.T) {
+	cats := fullCatalogue()
+	// Rename one entry to the stale id that shipped in suggestions.yaml.
+	for i := range cats {
+		if cats[i].ID == string(models.Secrets) {
+			cats[i].ID = "Secrets"
+		}
+	}
+
+	err := validateCategoriesMap(buildCategoriesMap(cats))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), string(models.Secrets))
+}
+
+func TestValidateCategoriesMapReportsEveryMissingCategory(t *testing.T) {
+	err := validateCategoriesMap(buildCategoriesMap(nil))
+	assert.Error(t, err)
+	for _, title := range models.CategoryTitles {
+		assert.Contains(t, err.Error(), string(title))
+	}
+}
+
+func TestNewServiceRejectsIncompleteCatalogue(t *testing.T) {
+	s, err := newService(fullCatalogue()[1:])
+	assert.Error(t, err)
+	assert.Nil(t, s)
+}
+
+func TestNewServiceAcceptsFullCatalogue(t *testing.T) {
+	s, err := newService(fullCatalogue())
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.Len(t, s.CategoriesMap, len(models.CategoryTitles))
+}


### PR DESCRIPTION
> **Stacked PR 1 of 7.** Review and merge in order: #130 → #131 → #132 → #133 → #134 → #135 → #136.

# Pull Request

## Description

**Two of the eight categories could never produce a suggestion.** A repo with no security tooling at all was told about six categories and never about secrets scanning or license compliance — arguably the two most valuable ones.

### Root cause

`models.CategoryTitle` uses the long form:

```go
Secrets  CategoryTitle = "Secrets Detection"
Licenses CategoryTitle = "License Compliance"
```

but `suggestions.yaml` declared those entries as `id: "Secrets"` and `id: "Licenses"`. `buildCategoriesMap` keys the map by the YAML id, while `FindSuggestions` looks up by category title:

```go
if category, ok := s.CategoriesMap[string(title)]; ok {
```

The lookup missed and the category was dropped — no error, no log. The rule files in `rules/storage/` already used the long form, so only `suggestions.yaml` had drifted.

### Reproduction

An empty git repo whose only workflow is a bare `actions/checkout` step:

```console
$ zanadir scan --dir /tmp/bare --output json | grep '"ID"'
    "ID": "SCA",
    "ID": "End Of Life",
    "ID": "Coverage",
    "ID": "Linter",
    "ID": "Performance Testing",
    "ID": "Unit Tests"
```

Six of eight. After this change all eight are reported.

### Fix

- Align the `suggestions.yaml` ids with the category titles.
- **Validate at startup** that every `models.CategoryTitle` resolves to an entry, so the two can no longer drift apart silently. Reintroducing the old id now fails loudly with `suggestions.yaml is missing an entry for category Secrets Detection` instead of quietly under-reporting.

### Related: `--excluded-categories` was also affected

The documented example `--excluded-categories "SCA,Secrets"` was a partial no-op — exclusions are compared against category titles, so `"Secrets"` matched nothing and the category was still reported. Unknown names are now rejected with the list of valid values, and matching is case-insensitive so `sca` works:

```console
$ zanadir scan --dir . --excluded-categories "Secrets"
Error: unknown category "Secrets": valid categories are SCA, Secrets Detection,
License Compliance, End Of Life, Coverage, Linter, Performance Testing, Unit Tests
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```bash
go build ./... && go vet ./... && go test -race ./...   # all pass
golangci-lint run ./...                                 # 0 issues
```

Verified end to end that a bare repo now yields all eight categories, that exclusion by canonical name works, and that a stale name errors.

**Note on existing coverage:** the previous suggester tests passed with the bug present — `TestFindSuggestionsWithExclusion` asserted the absence of an id (`"Secrets"`) that never appeared in the output under any circumstance. Added `TestFindSuggestionsCoversEveryCategory`, which asserts a scan with no findings yields every known category; I confirmed it fails when the old id is restored.

`TestCreateConfig` used placeholder category names (`"cat1"`, `"cat2"`) that are now correctly rejected, so it was updated to use real categories, plus a case asserting unknown names error.

## Notes for reviewers

- **Output change:** the JSON `ID` field for these two categories changes from `Secrets`/`Licenses` to `Secrets Detection`/`License Compliance`. Anything parsing those ids downstream needs updating. Making the ids match the titles is what removes the whole class of bug, so I favoured consistency over preserving the old strings — happy to revisit if you'd rather keep them stable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

