### PR TITLE
fix: tighten rule regexes to word boundaries

### DIFF
--- a/rules/regex_test.go
+++ b/rules/regex_test.go
@@ -1,0 +1,112 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/MustacheCase/zanadir/models"
+	"github.com/MustacheCase/zanadir/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+// findRule looks a rule up by id across every category.
+func findRule(t *testing.T, rs rules.RuleService, id string) *rules.Rule {
+	t.Helper()
+	for _, category := range models.CategoryTitles {
+		for _, r := range rs.GetCategoryRules(category) {
+			if r.ID == id {
+				return r
+			}
+		}
+	}
+	t.Fatalf("rule %q not found", id)
+	return nil
+}
+
+// The regexes were bare substrings. The shouldNotMatch cases are lookalikes
+// that used to produce a false "this category is covered".
+func TestRuleRegexPrecision(t *testing.T) {
+	rs, err := rules.NewRulesService()
+	assert.NoError(t, err)
+
+	tests := []struct {
+		ruleID         string
+		shouldMatch    []string
+		shouldNotMatch []string
+	}{
+		{
+			ruleID:         "trivy-rule",
+			shouldMatch:    []string{"trivy fs .", "aquasecurity/trivy-action", "run trivy"},
+			shouldNotMatch: []string{"trivyscanner", "mytrivy"},
+		},
+		{
+			ruleID:         "grype-rule",
+			shouldMatch:    []string{"grype dir:.", "anchore/grype"},
+			shouldNotMatch: []string{"grypeless"},
+		},
+		{
+			ruleID:         "snyk-rule",
+			shouldMatch:    []string{"snyk test", "snyk/actions/golang"},
+			shouldNotMatch: []string{"snyking"},
+		},
+		{
+			ruleID:         "gitleaks-rule",
+			shouldMatch:    []string{"gitleaks detect --source .", "gitleaks/gitleaks-action"},
+			shouldNotMatch: []string{"gitleaksy"},
+		},
+		{
+			ruleID:         "trufflehog-rule",
+			shouldMatch:    []string{"trufflehog git file://.", "trufflesecurity/trufflehog"},
+			shouldNotMatch: []string{"trufflehogsx"},
+		},
+		{
+			ruleID:         "detect-secrets-rule",
+			shouldMatch:    []string{"detect-secrets scan", "detect_secrets scan"},
+			shouldNotMatch: []string{"detect-secretsfoo"},
+		},
+		{
+			// "grant" is an English word and a SQL keyword.
+			ruleID:         "grant-rule",
+			shouldMatch:    []string{"grant check", "anchore/grant", "grant list"},
+			shouldNotMatch: []string{`psql -c "GRANT ALL PRIVILEGES ON db TO user"`, "grants-management", "grant the token access"},
+		},
+		{
+			ruleID:         "golangci-lint-rule",
+			shouldMatch:    []string{"golangci-lint run ./...", "golangci/golangci-lint-action"},
+			shouldNotMatch: []string{"mygolangci-lintx"},
+		},
+		{
+			ruleID:         "eslint-rule",
+			shouldMatch:    []string{"eslint .", "npx eslint --fix"},
+			shouldNotMatch: []string{"eslintrc", "myeslint"},
+		},
+		{
+			// "latest" contains "test", which ".*test.*" matched.
+			ruleID:         "unit-test-rule",
+			shouldMatch:    []string{"test", "unit-tests", "run-tests", "go test ./..."},
+			shouldNotMatch: []string{"latest", "deploy-latest", "protest-build", "contest"},
+		},
+		{
+			// A bare "ab" matched any standalone occurrence.
+			ruleID:         "apache-bench-rule",
+			shouldMatch:    []string{"apache-bench -n 100", "apachebench", "ab -n 1000 http://x/"},
+			shouldNotMatch: []string{"ab testing", "build ab", "grab a coffee"},
+		},
+		{
+			ruleID:         "codecov-rule",
+			shouldMatch:    []string{"codecov/codecov-action", "bash <(curl -s https://codecov.io/bash)"},
+			shouldNotMatch: []string{"mycodecovx"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ruleID, func(t *testing.T) {
+			rule := findRule(t, rs, tt.ruleID)
+			for _, s := range tt.shouldMatch {
+				assert.True(t, rule.Regex.MatchString(s), "%s should match %q", tt.ruleID, s)
+			}
+			for _, s := range tt.shouldNotMatch {
+				assert.False(t, rule.Regex.MatchString(s), "%s should NOT match %q", tt.ruleID, s)
+			}
+		})
+	}
+}

--- a/rules/storage/coverage.yaml
+++ b/rules/storage/coverage.yaml
@@ -2,19 +2,19 @@ rules:
   - id: "jacoco-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Coverage"]
-    regex: "(?i)jacoco"
+    regex: "(?i)\\bjacoco\\b"
 
   - id: "cobertura-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Coverage"]
-    regex: "(?i)cobertura"
+    regex: "(?i)\\bcobertura\\b"
 
   - id: "codecov-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Coverage"]
-    regex: "(?i)codecov"
+    regex: "(?i)\\bcodecov\\b"
 
   - id: "coverallsapp-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Coverage"]
-    regex: "(?i)coverallsapp"
+    regex: "(?i)\\bcoveralls(app)?\\b"

--- a/rules/storage/licenses.yaml
+++ b/rules/storage/licenses.yaml
@@ -2,14 +2,14 @@ rules:
   - id: "fossa-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["License Compliance"]
-    regex: "(?i)fossa"
+    regex: "(?i)\\bfossa\\b"
 
   - id: "licensefinder-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["License Compliance"]
-    regex: "(?i)license[-_]?finder"
+    regex: "(?i)\\blicense[-_]?finder\\b"
 
   - id: "grant-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["License Compliance"]
-    regex: "(?i)grant"
+    regex: "(?i)\\banchore/grant\\b|\\bgrant\\s+(?:check|list)\\b"

--- a/rules/storage/linter.yaml
+++ b/rules/storage/linter.yaml
@@ -2,27 +2,27 @@ rules:
   - id: "eslint-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Linter"]
-    regex: "(?i)eslint"
+    regex: "(?i)\\beslint\\b"
 
   - id: "pylint-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Linter"]
-    regex: "(?i)pylint"
+    regex: "(?i)\\bpylint\\b"
 
   - id: "golangci-lint-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Linter"]
-    regex: "(?i)golangci-lint"
+    regex: "(?i)\\bgolangci-lint\\b"
 
   - id: "rubocop-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Linter"]
-    regex: "(?i)rubocop"
+    regex: "(?i)\\brubocop\\b"
 
   - id: "flake8-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Linter"]
-    regex: "(?i)flake8"
+    regex: "(?i)\\bflake8\\b"
 
   - id: "oxsecurity-super-linter-rule"
     applyOn: [ "Artifact.Name", "Job.Package", "Job.Run" ]

--- a/rules/storage/performance-testing.yaml
+++ b/rules/storage/performance-testing.yaml
@@ -17,7 +17,7 @@ rules:
   - id: "apache-bench-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Performance Testing"]
-    regex: "(?i)\\b(?:ab|apache-bench|apachebench)\\b"
+    regex: "(?i)\\bapache-?bench\\b|\\bab\\s+-[nckt]\\b"
 
   - id: "artillery-rule"
     applyOn: [ "Artifact.Name", "Job.Package", "Job.Run" ]

--- a/rules/storage/sca.yaml
+++ b/rules/storage/sca.yaml
@@ -2,17 +2,17 @@ rules:
   - id: "grype-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["SCA"]
-    regex: "(?i)grype"
+    regex: "(?i)\\bgrype\\b"
 
   - id: "trivy-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["SCA"]
-    regex: "(?i)trivy"
+    regex: "(?i)\\btrivy\\b"
 
   - id: "snyk-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["SCA"]
-    regex: "(?i)snyk"
+    regex: "(?i)\\bsnyk\\b"
 
   - id: "anchore-rule"
     applyOn: ["Job.Package"]

--- a/rules/storage/secrets.yaml
+++ b/rules/storage/secrets.yaml
@@ -2,19 +2,19 @@ rules:
   - id: "gitleaks-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Secrets Detection"]
-    regex: "(?i)gitleaks"
+    regex: "(?i)\\bgitleaks\\b"
 
   - id: "trufflehog-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Secrets Detection"]
-    regex: "(?i)(?:trufflesecurity/trufflehog|trufflehog)"
+    regex: "(?i)\\btrufflehog\\b"
 
   - id: "gitguardian-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Secrets Detection"]
-    regex: "(?i)ggshield|gitguardian"
+    regex: "(?i)\\b(?:ggshield|gitguardian)\\b"
 
   - id: "detect-secrets-rule"
     applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
     categories: ["Secrets Detection"]
-    regex: "(?i)detect[-_]?secrets"
+    regex: "(?i)\\bdetect[-_]?secrets\\b"

--- a/rules/storage/unit-tests.yaml
+++ b/rules/storage/unit-tests.yaml
@@ -2,4 +2,4 @@ rules:
   - id: "unit-test-rule"
     applyOn: ["Artifact.Name", "Job.Name"]
     categories: ["Unit Tests"]
-    regex: "(?i).*test.*"
+    regex: "(?i)\\btests?\\b"


### PR DESCRIPTION
> **Stacked PR 3 of 7.** Review and merge in order: #130 → #131 → #132 → #133 → #134 → #135 → #136. Based on #131, so the diff shown is only this PR's own changes.

# Pull Request

## Description

Most rules matched a **bare substring**, so any text containing the tool name counted as coverage. These are verified false positives from the shipped patterns:

| Rule regex | Matched (wrongly) |
|---|---|
| `(?i)grant` | `psql -c "GRANT ALL PRIVILEGES ON db TO user"`, `grants-management`, `grant the token access` |
| `(?i).*test.*` | `latest`, `deploy-latest`, `protest-build`, `contest` |
| `(?i)trivy` | `trivyscanner`, `mytrivy` |
| `(?i)eslint` | `eslintrc`, `myeslint` |
| `\b(?:ab\|apache-bench\|apachebench)\b` | `ab testing`, `build ab` |

A false *match* is worse than a false miss here: it silently marks a category as covered and suppresses a suggestion the user should have seen. A job named `deploy-latest` was enough to convince zanadir the repo had unit testing.

## Changes

Tool names are now anchored on word boundaries. Three rules needed more than a boundary:

- **`grant`** — an ordinary English word *and* a SQL keyword. Now requires either the `anchore/grant` package or a `grant check` / `grant list` invocation.
- **`unit-test`** — `.*test.*` matched any substring. Now `\btests?\b`, so `latest` and `contest` no longer qualify while `unit-tests` and `go test ./...` still do.
- **`apache-bench`** — accepted a bare `ab` anywhere. Now requires the tool name or an `ab -n`-style invocation.

Rules already matching a specific path (`anchore/scan-action`, `super-linter/super-linter`, `xeol-io/xeol-action`) are left alone — they're specific enough.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```bash
go vet ./... && go test -race ./...   # all pass
golangci-lint run ./...               # 0 issues
```

Added `TestRuleRegexPrecision`, a table test pinning match/non-match behaviour per rule, using the lookalikes above as negative cases. I confirmed separately that every negative case genuinely matches under the *old* pattern, so the test would fail if the regexes were reverted.

Word boundaries still allow the package forms: `\btrivy\b` matches `aquasecurity/trivy-action`, and `\btrufflehog\b` matches `trufflesecurity/trufflehog` — which let the trufflehog rule collapse from an alternation to a single term.

## Notes for reviewers

- **Direction of change:** this makes rules stricter, so a repo that was previously considered covered by a coincidental substring will now get a suggestion. That's the intended correction, but it means some users will see *new* suggestions appear after upgrading.
- **Stacking with #131:** that PR applies rules to shell command text, which widens the text each regex sees and makes loose matching considerably riskier — `(?i)grant` against a whole script block would fire constantly. The two are independent and touch different lines of the same YAML files (`applyOn:` there, `regex:` here), so they merge cleanly in either order, but landing both is what makes command matching safe.
- I did **not** try to broaden coverage (e.g. detecting `go test -cover` for the Coverage category). That's a rules-content question, separate from precision.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no user-facing interface change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

