### PR TITLE
feat: add SARIF output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ zanadir scan --dir /path/to/your/repo
 
 ### Output Formats
 
-Zanadir supports two output formats: table (default) and JSON.
+Zanadir supports three output formats: table (default), JSON and SARIF.
 
 #### Table Output (Default)
 
@@ -97,6 +97,33 @@ zanadir scan --dir . --output json
     ]
   }
 ]
+```
+
+#### SARIF Output
+
+```sh
+zanadir scan --dir . --output sarif
+```
+
+SARIF is the standard interchange format for static analysis results. Emitting
+it lets uncovered categories show up in GitHub's Security tab, and in any other
+SARIF-consuming platform, alongside your other scanners.
+
+Each uncovered category becomes one SARIF rule and one result at `warning`
+level, with the suggested tools listed in the result's help text. Results carry
+no file location, because a missing control is the absence of configuration
+rather than a defect on a particular line.
+
+To publish the report from a GitHub Actions workflow:
+
+```yaml
+- name: Run zanadir
+  run: zanadir scan --dir . --output sarif > zanadir.sarif
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: zanadir.sarif
 ```
 
 ### Advanced Usage

--- a/app/app.go
+++ b/app/app.go
@@ -51,7 +51,7 @@ func NewApp() *cobra.Command {
 	scanCmd.Flags().StringSliceP("excluded-categories", "e", []string{}, "List of excluded categories (optional)")
 	scanCmd.Flags().Bool("enforce", false, "Fails the CI process when at least one rule is met (optional)")
 	scanCmd.Flags().Bool("debug", false, "Run the tool using debug mode (optional)")
-	scanCmd.Flags().StringP("output", "o", "table", "Output format of the tool (Table, Json) (optional)")
+	scanCmd.Flags().StringP("output", "o", "table", "Output format of the tool (table, json, sarif) (optional)")
 
 	_ = scanCmd.MarkFlagRequired("dir")
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 const (
 	OutputJSON  = "json"
 	OutputTable = "table"
+	OutputSARIF = "sarif"
 )
 
 type Config struct {
@@ -63,9 +64,8 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 	enforce, _ := cmd.Flags().GetBool("enforce")
 	debug, _ := cmd.Flags().GetBool("debug")
 	output, _ := cmd.Flags().GetString("output")
-	// Validate that output is either OutputJSON or OutputTable
-	if output != OutputJSON && output != OutputTable {
-		return nil, fmt.Errorf("unsupported output format: %s", output)
+	if output != OutputJSON && output != OutputTable && output != OutputSARIF {
+		return nil, fmt.Errorf("unsupported output format: %s (expected %s, %s or %s)", output, OutputTable, OutputJSON, OutputSARIF)
 	}
 
 	return &Config{

--- a/output/output.go
+++ b/output/output.go
@@ -45,6 +45,15 @@ func wrapText(text string, lineWidth int) string {
 }
 
 func (s *service) Response(suggestions []*suggester.CategorySuggestion, responseType string) error {
+	if responseType == config.OutputSARIF {
+		report, err := renderSarif(suggestions)
+		if err != nil {
+			return err
+		}
+		fmt.Println(report)
+		return nil
+	}
+
 	if responseType == config.OutputTable {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{"Category", "Description", "Suggested Tools"})

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -85,3 +85,36 @@ func TestResponse_TableOutput(t *testing.T) {
 		t.Errorf("table header is missing or incorrect in output:\n%v", out)
 	}
 }
+
+func TestResponse_SARIFOutput(t *testing.T) {
+	service := NewOutputService()
+	suggestions := getSampleSuggestions()
+
+	out := captureStdout(func() {
+		err := service.Response(suggestions, config.OutputSARIF)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var report sarifLog
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("output is not valid SARIF JSON: %v", err)
+	}
+
+	if report.Version != sarifVersion {
+		t.Errorf("expected SARIF version %q, got %q", sarifVersion, report.Version)
+	}
+	if len(report.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(report.Runs))
+	}
+	if got := len(report.Runs[0].Results); got != len(suggestions) {
+		t.Errorf("expected %d results, got %d", len(suggestions), got)
+	}
+}
+
+func TestWrapTextEmptyInput(t *testing.T) {
+	if got := wrapText("   ", 10); got != "" {
+		t.Errorf("expected empty string for blank input, got %q", got)
+	}
+}

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -1,0 +1,140 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MustacheCase/zanadir/suggester"
+)
+
+// Minimal SARIF 2.1.0 document, covering only the fields zanadir populates.
+const (
+	sarifVersion = "2.1.0"
+	sarifSchema  = "https://json.schemastore.org/sarif-2.1.0.json"
+	toolName     = "zanadir"
+	toolURI      = "https://github.com/MustacheCase/zanadir"
+)
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	ShortDescription     sarifMessage      `json:"shortDescription"`
+	FullDescription      sarifMessage      `json:"fullDescription"`
+	Help                 sarifMessage      `json:"help"`
+	DefaultConfiguration sarifRuleConfig   `json:"defaultConfiguration"`
+	Properties           sarifRuleProperty `json:"properties"`
+}
+
+type sarifRuleConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifRuleProperty struct {
+	Tags []string `json:"tags"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifResult struct {
+	RuleID              string            `json:"ruleId"`
+	Level               string            `json:"level"`
+	Message             sarifMessage      `json:"message"`
+	PartialFingerprints map[string]string `json:"partialFingerprints"`
+}
+
+// helpText renders a category's suggested tools as a list.
+func helpText(suggestion *suggester.CategorySuggestion) string {
+	var b strings.Builder
+	b.WriteString(suggestion.Description)
+	if len(suggestion.Suggestions) == 0 {
+		return b.String()
+	}
+	b.WriteString("\n\nSuggested tools:\n")
+	for _, tool := range suggestion.Suggestions {
+		fmt.Fprintf(&b, "- %s (%s): %s\n", tool.Name, tool.Repository, tool.Description)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// buildSarif converts category suggestions into a SARIF log: one rule and one
+// result per uncovered category. Results carry no physical location, since a
+// missing control is the absence of configuration rather than a defect in a file.
+func buildSarif(suggestions []*suggester.CategorySuggestion) sarifLog {
+	rules := make([]sarifRule, 0, len(suggestions))
+	results := make([]sarifResult, 0, len(suggestions))
+
+	for _, suggestion := range suggestions {
+		toolNames := make([]string, 0, len(suggestion.Suggestions))
+		for _, tool := range suggestion.Suggestions {
+			toolNames = append(toolNames, tool.Name)
+		}
+
+		rules = append(rules, sarifRule{
+			ID:                   suggestion.ID,
+			Name:                 suggestion.Name,
+			ShortDescription:     sarifMessage{Text: fmt.Sprintf("Missing CI/CD coverage: %s", suggestion.Name)},
+			FullDescription:      sarifMessage{Text: suggestion.Description},
+			Help:                 sarifMessage{Text: helpText(suggestion)},
+			DefaultConfiguration: sarifRuleConfig{Level: "warning"},
+			Properties:           sarifRuleProperty{Tags: []string{"ci-cd", "coverage"}},
+		})
+
+		message := fmt.Sprintf("No %s tooling detected in this repository's CI configuration.", suggestion.Name)
+		if len(toolNames) > 0 {
+			message = fmt.Sprintf("%s Consider adding one of: %s.", message, strings.Join(toolNames, ", "))
+		}
+
+		results = append(results, sarifResult{
+			RuleID:  suggestion.ID,
+			Level:   "warning",
+			Message: sarifMessage{Text: message},
+			// The category is the finding's whole identity.
+			PartialFingerprints: map[string]string{"categoryId": suggestion.ID},
+		})
+	}
+
+	return sarifLog{
+		Schema:  sarifSchema,
+		Version: sarifVersion,
+		Runs: []sarifRun{{
+			Tool: sarifTool{Driver: sarifDriver{
+				Name:           toolName,
+				InformationURI: toolURI,
+				Rules:          rules,
+			}},
+			Results: results,
+		}},
+	}
+}
+
+func renderSarif(suggestions []*suggester.CategorySuggestion) (string, error) {
+	data, err := json.MarshalIndent(buildSarif(suggestions), "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal SARIF report: %w", err)
+	}
+	return string(data), nil
+}

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -1,0 +1,107 @@
+package output
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MustacheCase/zanadir/suggester"
+	"github.com/stretchr/testify/assert"
+)
+
+func testSuggestions() []*suggester.CategorySuggestion {
+	return []*suggester.CategorySuggestion{
+		{
+			ID:          "SCA",
+			Name:        "SCA Open Source Tools",
+			Description: "SCA tools help track open-source components.",
+			Suggestions: []*suggester.Suggestion{
+				{Name: "Trivy", Repository: "https://github.com/aquasecurity/trivy", Description: "A vulnerability scanner."},
+				{Name: "Grype", Repository: "https://github.com/anchore/grype", Description: "Another scanner."},
+			},
+		},
+		{
+			ID:          "Coverage",
+			Name:        "Coverage Tools",
+			Description: "Coverage tools measure test completeness.",
+		},
+	}
+}
+
+func TestBuildSarifStructure(t *testing.T) {
+	log := buildSarif(testSuggestions())
+
+	assert.Equal(t, sarifVersion, log.Version)
+	assert.Equal(t, sarifSchema, log.Schema)
+	assert.Len(t, log.Runs, 1)
+
+	run := log.Runs[0]
+	assert.Equal(t, toolName, run.Tool.Driver.Name)
+	assert.Len(t, run.Tool.Driver.Rules, 2, "one rule per uncovered category")
+	assert.Len(t, run.Results, 2, "one result per uncovered category")
+
+	// Consumers drop results referencing an undeclared rule.
+	declared := make(map[string]bool, len(run.Tool.Driver.Rules))
+	for _, rule := range run.Tool.Driver.Rules {
+		declared[rule.ID] = true
+	}
+	for _, result := range run.Results {
+		assert.True(t, declared[result.RuleID], "result references undeclared rule %q", result.RuleID)
+		assert.Equal(t, "warning", result.Level)
+		assert.NotEmpty(t, result.Message.Text)
+		assert.Equal(t, result.RuleID, result.PartialFingerprints["categoryId"])
+	}
+}
+
+func TestSarifHelpListsTools(t *testing.T) {
+	log := buildSarif(testSuggestions())
+
+	var scaHelp, coverageHelp string
+	for _, rule := range log.Runs[0].Tool.Driver.Rules {
+		switch rule.ID {
+		case "SCA":
+			scaHelp = rule.Help.Text
+		case "Coverage":
+			coverageHelp = rule.Help.Text
+		}
+	}
+
+	assert.Contains(t, scaHelp, "Trivy")
+	assert.Contains(t, scaHelp, "https://github.com/aquasecurity/trivy")
+	assert.Contains(t, scaHelp, "Grype")
+
+	// No tools means no tools section.
+	assert.Equal(t, "Coverage tools measure test completeness.", coverageHelp)
+	assert.NotContains(t, coverageHelp, "Suggested tools")
+}
+
+func TestSarifMessageMentionsTools(t *testing.T) {
+	log := buildSarif(testSuggestions())
+
+	for _, result := range log.Runs[0].Results {
+		if result.RuleID == "SCA" {
+			assert.Contains(t, result.Message.Text, "Trivy, Grype")
+		}
+	}
+}
+
+func TestRenderSarifIsValidJSON(t *testing.T) {
+	report, err := renderSarif(testSuggestions())
+	assert.NoError(t, err)
+
+	var decoded map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(report), &decoded))
+	assert.Equal(t, "2.1.0", decoded["version"])
+	assert.True(t, strings.HasPrefix(report, "{"))
+}
+
+// SARIF requires runs[].results, so it must serialise as [] rather than null.
+func TestRenderSarifWithNoSuggestions(t *testing.T) {
+	report, err := renderSarif(nil)
+	assert.NoError(t, err)
+	assert.Contains(t, report, `"results": []`)
+	assert.Contains(t, report, `"rules": []`)
+
+	var decoded map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(report), &decoded))
+}


### PR DESCRIPTION
> **Stacked PR 4 of 7.** Review and merge in order: #130 → #131 → #132 → #133 → #134 → #135 → #136. Based on #132, so the diff shown is only this PR's own changes.

# Pull Request

## Description

Adds `--output sarif`. SARIF is the standard interchange format for static analysis results, so emitting it lets uncovered categories appear in **GitHub's Security tab** — and in any other SARIF-consuming platform — next to the scanners a team already runs, rather than only in terminal output someone has to read.

This is the cheapest distribution win available to the project: no changes to scanning, matching or suggestion logic, just a third renderer.

### Shape of the report

Each uncovered category becomes one SARIF rule and one result at `warning` level:

```json
{
  "ruleId": "SCA",
  "level": "warning",
  "message": {
    "text": "No SCA Open Source Tools tooling detected in this repository's CI configuration. Consider adding one of: Grype, Trivy, Snyk."
  },
  "partialFingerprints": { "categoryId": "SCA" }
}
```

The suggested tools, with repository links and descriptions, are rendered into the rule's `help` text, which is what consumers show when a result is expanded.

### Two deliberate design decisions

**No physical locations.** A missing control is the *absence* of configuration, not a defect at a particular line. Anchoring these results to an arbitrary file would be misleading, so `locations` is omitted (it's optional in the spec). GitHub surfaces such results at the repository level.

**`partialFingerprints` on the category id.** The category is the entire identity of the finding, so it's also what makes it stable across runs — this keeps consumers from re-opening the same alert every scan.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Validated against the official schema**, not just eyeballed. I fetched `sarif-2.1.0.json` from schemastore and validated real tool output with `jsonschema`:

```
SARIF VALID against sarif-2.1.0 schema
results: 6 rules: 6
```

The empty report — what a fully covered repo produces — was validated separately, since `results` and `rules` must serialise as `[]` rather than `null`:

```
EMPTY SARIF VALID
```

```bash
go vet ./... && go test -race ./...   # all pass
golangci-lint run ./...               # 0 issues
```

Go tests cover document structure, the rule/result referential invariant (every result references a declared rule, or consumers silently drop it), help text with and without tools, and the empty case.

## Notes for reviewers

- Only the `output` package gains logic; `config` gains the format constant and its validation, and the `--output` flag help was corrected — it advertised `(Table, Json)` with capitalised names that were never accepted values.
- README documents the format and includes a ready-to-use `upload-sarif` workflow snippet.
- `app/app_test.go` is unformatted on `main`; left untouched to keep the diff scoped.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

