### PR TITLE
feat: add --fail-on and baseline support for enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,60 @@ Zanadir provides an `--enforce` flag to ensure that all CI/CD suggestions are fu
 zanadir scan --dir . --enforce
 ```
 
+The category that failed the build is printed to stderr:
+
+```
+Enforcement failed: uncovered categories: SCA, Secrets Detection
+```
+
+#### Failing on Specific Categories
+
+`--enforce` is all-or-nothing, which makes it hard to adopt on an existing
+repository: a single uncovered category fails every build. Use `--fail-on` to
+enforce only the categories you care about, while the rest stay informational:
+
+```sh
+zanadir scan --dir . --fail-on "SCA,Secrets Detection"
+```
+
+`--fail-on` implies enforcement, so `--enforce` is not needed alongside it.
+Category names are matched case-insensitively.
+
+#### Baseline
+
+A baseline records the gaps a repository knowingly accepts. Those categories
+are still reported, but they no longer fail a scan — so enforcement can be
+switched on before everything is fixed, and only *new* gaps break the build.
+
+Generate one from the current state:
+
+```sh
+zanadir scan --dir . --write-baseline
+```
+
+This writes `.zanadir-baseline.yaml` (override with `--baseline <path>`) and
+exits successfully:
+
+```yaml
+# zanadir baseline: categories that are uncovered but accepted.
+# These are still reported; they just do not fail a scan.
+# Regenerate with: zanadir scan --dir . --write-baseline
+version: 1
+categories:
+    - Coverage
+    - Performance Testing
+```
+
+Then enforce against it. The scan passes while the repository's gaps match the
+baseline, and fails as soon as a new one appears:
+
+```sh
+zanadir scan --dir . --enforce --baseline .zanadir-baseline.yaml
+```
+
+Commit the baseline so the accepted gaps are reviewable, and shrink it over
+time.
+
 #### Debug Mode
 
 Get detailed logging information:

--- a/app/app.go
+++ b/app/app.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/MustacheCase/zanadir/config"
@@ -31,11 +33,8 @@ var scanCmd = &cobra.Command{
 		}
 
 		if err := scanRepo(config); err != nil {
-			if _, ok := err.(*models.EnforceError); ok {
-				// Do not print the error, just exit
-				os.Exit(1)
-			}
-			fmt.Printf("Error: scan repo failed: %v", err)
+			w, msg := scanErrorReport(err)
+			_, _ = fmt.Fprint(w, msg)
 			os.Exit(1)
 		}
 	},
@@ -49,13 +48,28 @@ func NewApp() *cobra.Command {
 	// Add flags to scan command
 	scanCmd.Flags().StringP("dir", "d", "", "Path to the GitHub repository directory (required)")
 	scanCmd.Flags().StringSliceP("excluded-categories", "e", []string{}, "List of excluded categories (optional)")
-	scanCmd.Flags().Bool("enforce", false, "Fails the CI process when at least one rule is met (optional)")
+	scanCmd.Flags().Bool("enforce", false, "Fails the CI process when any category is uncovered (optional)")
+	scanCmd.Flags().StringSlice("fail-on", []string{}, "Fail only when these specific categories are uncovered (optional)")
+	scanCmd.Flags().String("baseline", "", "Path to a baseline file of already-accepted gaps (optional)")
+	scanCmd.Flags().Bool("write-baseline", false, "Write the current uncovered categories to the baseline file and exit successfully (optional)")
 	scanCmd.Flags().Bool("debug", false, "Run the tool using debug mode (optional)")
 	scanCmd.Flags().StringP("output", "o", "table", "Output format of the tool (table, json, sarif) (optional)")
 
 	_ = scanCmd.MarkFlagRequired("dir")
 
 	return rootCmd
+}
+
+// scanErrorReport decides how a failed scan is reported. An enforcement failure
+// is the tool doing its job, so it names the categories on stderr — not obvious
+// once --fail-on or a baseline narrows enforcement down. Anything else is an
+// operational error and keeps its original destination.
+func scanErrorReport(err error) (io.Writer, string) {
+	var enforceErr *models.EnforceError
+	if errors.As(err, &enforceErr) {
+		return os.Stderr, fmt.Sprintf("Enforcement failed: %v\n", err)
+	}
+	return os.Stdout, fmt.Sprintf("Error: scan repo failed: %v", err)
 }
 
 // scanRepo function

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,9 +1,13 @@
 package app
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/MustacheCase/zanadir/config"
+	"github.com/MustacheCase/zanadir/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,11 +29,43 @@ func TestScanCmdFlags(t *testing.T) {
 
 	enforceFlag := cmd.Flags().Lookup("enforce")
 	assert.NotNil(t, enforceFlag, "The 'enforce' flag should be defined")
-	assert.Equal(t, "Fails the CI process when at least one rule is met (optional)", enforceFlag.Usage)
+	assert.Equal(t, "Fails the CI process when any category is uncovered (optional)", enforceFlag.Usage)
+
+	assert.NotNil(t, cmd.Flags().Lookup("fail-on"), "The 'fail-on' flag should be defined")
+	assert.NotNil(t, cmd.Flags().Lookup("baseline"), "The 'baseline' flag should be defined")
+	assert.NotNil(t, cmd.Flags().Lookup("write-baseline"), "The 'write-baseline' flag should be defined")
 }
 
 func TestScanRepo(t *testing.T) {
 	mockConfig := &config.Config{}
 	err := scanRepo(mockConfig)
 	assert.NotNil(t, err, "scanRepo should return an error when handler setup fails")
+}
+
+// Enforcement failures are an expected outcome, not a crash: they belong on
+// stderr with the offending categories named.
+func TestScanErrorReportRoutesEnforcementToStderr(t *testing.T) {
+	w, msg := scanErrorReport(models.NewEnforceError("uncovered categories: SCA"))
+
+	assert.Equal(t, os.Stderr, w)
+	assert.Contains(t, msg, "Enforcement failed")
+	assert.Contains(t, msg, "SCA")
+}
+
+func TestScanErrorReportRoutesOperationalErrorToStdout(t *testing.T) {
+	w, msg := scanErrorReport(errors.New("handler setup failed"))
+
+	assert.Equal(t, os.Stdout, w)
+	assert.Contains(t, msg, "scan repo failed")
+	assert.Contains(t, msg, "handler setup failed")
+}
+
+// A wrapped enforcement failure is still an enforcement failure.
+func TestScanErrorReportUnwrapsEnforceError(t *testing.T) {
+	wrapped := fmt.Errorf("execute: %w", models.NewEnforceError("uncovered categories: Coverage"))
+
+	w, msg := scanErrorReport(wrapped)
+
+	assert.Equal(t, os.Stderr, w)
+	assert.Contains(t, msg, "Enforcement failed")
 }

--- a/baseline/baseline.go
+++ b/baseline/baseline.go
@@ -1,0 +1,77 @@
+package baseline
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultPath is used when --baseline is given without a path.
+const DefaultPath = ".zanadir-baseline.yaml"
+
+// Version is the baseline schema version.
+const Version = 1
+
+// Baseline records categories a repository knowingly does not cover. They are
+// still reported, but do not fail a scan; only gaps appearing later do.
+type Baseline struct {
+	Version    int      `yaml:"version"`
+	Categories []string `yaml:"categories"`
+}
+
+// Load reads a baseline. A missing file means nothing has been accepted yet.
+func Load(path string) (*Baseline, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is operator-supplied
+	if os.IsNotExist(err) {
+		return &Baseline{Version: Version}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read baseline %s: %w", path, err)
+	}
+
+	var b Baseline
+	if err := yaml.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("failed to parse baseline %s: %w", path, err)
+	}
+	if b.Version != Version {
+		return nil, fmt.Errorf("baseline %s has unsupported version %d, expected %d", path, b.Version, Version)
+	}
+	return &b, nil
+}
+
+// Write saves the given categories as the accepted baseline.
+func Write(path string, categories []string) error {
+	sorted := append([]string(nil), categories...)
+	sort.Strings(sorted)
+
+	b := Baseline{Version: Version, Categories: sorted}
+	data, err := yaml.Marshal(b)
+	if err != nil {
+		return fmt.Errorf("failed to marshal baseline: %w", err)
+	}
+
+	header := "# zanadir baseline: categories that are uncovered but accepted.\n" +
+		"# These are still reported; they just do not fail a scan.\n" +
+		"# Regenerate with: zanadir scan --dir . --write-baseline\n"
+
+	if err := os.WriteFile(path, []byte(header+string(data)), 0o600); err != nil {
+		return fmt.Errorf("failed to write baseline %s: %w", path, err)
+	}
+	return nil
+}
+
+// Contains reports whether a category has been accepted.
+func (b *Baseline) Contains(category string) bool {
+	if b == nil {
+		return false
+	}
+	for _, c := range b.Categories {
+		if strings.EqualFold(strings.TrimSpace(c), category) {
+			return true
+		}
+	}
+	return false
+}

--- a/baseline/baseline_test.go
+++ b/baseline/baseline_test.go
@@ -1,0 +1,96 @@
+package baseline_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MustacheCase/zanadir/baseline"
+	"github.com/stretchr/testify/assert"
+)
+
+// A missing baseline must not error, or the first enforcing run would break.
+func TestLoadMissingFileIsNotAnError(t *testing.T) {
+	b, err := baseline.Load(filepath.Join(t.TempDir(), "absent.yaml"))
+	assert.NoError(t, err)
+	assert.NotNil(t, b)
+	assert.Empty(t, b.Categories)
+	assert.False(t, b.Contains("SCA"))
+}
+
+func TestWriteThenLoadRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), baseline.DefaultPath)
+
+	assert.NoError(t, baseline.Write(path, []string{"Coverage", "SCA"}))
+
+	b, err := baseline.Load(path)
+	assert.NoError(t, err)
+	assert.Equal(t, baseline.Version, b.Version)
+	assert.Equal(t, []string{"Coverage", "SCA"}, b.Categories)
+	assert.True(t, b.Contains("SCA"))
+	assert.False(t, b.Contains("Linter"))
+}
+
+func TestWriteSortsForStableDiffs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "b.yaml")
+	assert.NoError(t, baseline.Write(path, []string{"Linter", "Coverage", "SCA"}))
+
+	b, err := baseline.Load(path)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Coverage", "Linter", "SCA"}, b.Categories)
+}
+
+func TestWriteIncludesExplanatoryHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "b.yaml")
+	assert.NoError(t, baseline.Write(path, []string{"SCA"}))
+
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "# zanadir baseline")
+	assert.Contains(t, string(data), "--write-baseline")
+}
+
+func TestContainsIsCaseInsensitive(t *testing.T) {
+	b := &baseline.Baseline{Version: baseline.Version, Categories: []string{"  sca  ", "Unit Tests"}}
+	assert.True(t, b.Contains("SCA"))
+	assert.True(t, b.Contains("unit tests"))
+	assert.False(t, b.Contains("Coverage"))
+}
+
+func TestLoadRejectsUnknownVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "b.yaml")
+	assert.NoError(t, os.WriteFile(path, []byte("version: 99\ncategories: []\n"), 0o600))
+
+	_, err := baseline.Load(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported version")
+}
+
+func TestLoadRejectsMalformedYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "b.yaml")
+	assert.NoError(t, os.WriteFile(path, []byte("categories: [oops\n"), 0o600))
+
+	_, err := baseline.Load(path)
+	assert.Error(t, err)
+}
+
+func TestNilBaselineContainsNothing(t *testing.T) {
+	var b *baseline.Baseline
+	assert.False(t, b.Contains("SCA"))
+}
+
+// A directory is readable-but-not-a-file: distinct from "absent", and must not
+// be mistaken for an empty baseline.
+func TestLoadReportsUnreadablePath(t *testing.T) {
+	_, err := baseline.Load(t.TempDir())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read baseline")
+}
+
+func TestWriteReportsUnwritablePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-such-dir", "b.yaml")
+
+	err := baseline.Write(path, []string{"SCA"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write baseline")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/MustacheCase/zanadir/baseline"
 	"github.com/MustacheCase/zanadir/models"
 	"github.com/spf13/cobra"
 )
@@ -20,8 +21,13 @@ type Config struct {
 	Dir                string
 	ExcludedCategories []string
 	Enforce            bool
-	Debug              bool
-	Output             string
+	// FailOn limits enforcement to specific categories; empty means all.
+	FailOn []string
+	// Baseline is the path to a file of already-accepted gaps.
+	Baseline      string
+	WriteBaseline bool
+	Debug         bool
+	Output        string
 }
 
 // normalizeCategories canonicalises category names and rejects unknown ones.
@@ -62,6 +68,20 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 	}
 
 	enforce, _ := cmd.Flags().GetBool("enforce")
+	failOn, _ := cmd.Flags().GetStringSlice("fail-on")
+	failOn, err = normalizeCategories(failOn)
+	if err != nil {
+		return nil, err
+	}
+
+	baselinePath, _ := cmd.Flags().GetString("baseline")
+	writeBaseline, _ := cmd.Flags().GetBool("write-baseline")
+
+	// --baseline may be given without a value, meaning the default location.
+	if writeBaseline && baselinePath == "" {
+		baselinePath = baseline.DefaultPath
+	}
+
 	debug, _ := cmd.Flags().GetBool("debug")
 	output, _ := cmd.Flags().GetString("output")
 	if output != OutputJSON && output != OutputTable && output != OutputSARIF {
@@ -72,6 +92,9 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 		Dir:                dir,
 		ExcludedCategories: excludedCategories,
 		Enforce:            enforce,
+		FailOn:             failOn,
+		Baseline:           baselinePath,
+		WriteBaseline:      writeBaseline,
 		Debug:              debug,
 		Output:             output,
 	}, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,8 +3,10 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/MustacheCase/zanadir/baseline"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -96,7 +98,31 @@ func newScanCmd(dir string, excluded []string) *cobra.Command {
 	cmd.Flags().Bool("enforce", false, "enforce")
 	cmd.Flags().Bool("debug", false, "debug")
 	cmd.Flags().String("output", OutputTable, "output")
+	cmd.Flags().StringSlice("fail-on", nil, "fail on")
+	cmd.Flags().String("baseline", "", "baseline")
+	cmd.Flags().Bool("write-baseline", false, "write baseline")
 	return cmd
+}
+
+func newFailOnCmd(dir string, failOn []string) *cobra.Command {
+	cmd := newScanCmd(dir, nil)
+	_ = cmd.Flags().Set("fail-on", strings.Join(failOn, ","))
+	return cmd
+}
+
+// An unvalidated --fail-on silently enforces nothing, so a typo turns CI green
+// exactly when it should go red.
+func TestCreateConfigRejectsUnknownFailOnCategory(t *testing.T) {
+	cfg, err := CreateConfig(newFailOnCmd(t.TempDir(), []string{"Lintr"}))
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "unknown category")
+}
+
+func TestCreateConfigNormalizesFailOn(t *testing.T) {
+	cfg, err := CreateConfig(newFailOnCmd(t.TempDir(), []string{"sca", "secrets detection"}))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"SCA", "Secrets Detection"}, cfg.FailOn)
 }
 
 func TestNormalizeCategories(t *testing.T) {
@@ -142,4 +168,15 @@ func TestCreateConfigNormalizesExcludedCategories(t *testing.T) {
 	cfg, err := CreateConfig(newScanCmd(dir, []string{"sca"}))
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"SCA"}, cfg.ExcludedCategories)
+}
+
+// --write-baseline without --baseline must still land somewhere predictable.
+func TestCreateConfigDefaultsBaselinePathForWrite(t *testing.T) {
+	cmd := newScanCmd(t.TempDir(), nil)
+	assert.NoError(t, cmd.Flags().Set("write-baseline", "true"))
+
+	cfg, err := CreateConfig(cmd)
+	assert.NoError(t, err)
+	assert.True(t, cfg.WriteBaseline)
+	assert.Equal(t, baseline.DefaultPath, cfg.Baseline)
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,6 +1,10 @@
 package handler
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/MustacheCase/zanadir/baseline"
 	"github.com/MustacheCase/zanadir/config"
 	"github.com/MustacheCase/zanadir/logger"
 	"github.com/MustacheCase/zanadir/matcher"
@@ -50,13 +54,68 @@ func (h *Handler) Execute(cfg *config.Config) error {
 		return err
 	}
 
-	if cfg.Enforce && len(suggestions) > 0 {
-		debugf("Enforce mode enabled and suggestions found, failing scan")
-		return models.NewEnforceError("Enforce mode enabled and suggestions found")
+	uncovered := make([]string, 0, len(suggestions))
+	for _, s := range suggestions {
+		uncovered = append(uncovered, s.ID)
+	}
+
+	if cfg.WriteBaseline {
+		if err := baseline.Write(cfg.Baseline, uncovered); err != nil {
+			return err
+		}
+		debugf("Wrote %d categories to baseline %s", len(uncovered), cfg.Baseline)
+		return nil
+	}
+
+	failing, err := h.enforceableCategories(cfg, uncovered, debugf)
+	if err != nil {
+		return err
+	}
+
+	if len(failing) > 0 {
+		debugf("Failing scan for categories: %s", strings.Join(failing, ", "))
+		return models.NewEnforceError(fmt.Sprintf("uncovered categories: %s", strings.Join(failing, ", ")))
 	}
 
 	debugf("Scan completed successfully")
 	return nil
+}
+
+// enforceableCategories narrows uncovered categories to those that should fail
+// the scan: not accepted in the baseline, and named by --fail-on if given.
+func (h *Handler) enforceableCategories(cfg *config.Config, uncovered []string, debugf func(string, ...interface{})) ([]string, error) {
+	if !cfg.Enforce && len(cfg.FailOn) == 0 {
+		return nil, nil
+	}
+
+	var accepted *baseline.Baseline
+	if cfg.Baseline != "" {
+		loaded, err := baseline.Load(cfg.Baseline)
+		if err != nil {
+			return nil, err
+		}
+		accepted = loaded
+		debugf("Loaded baseline %s with %d accepted categories", cfg.Baseline, len(loaded.Categories))
+	}
+
+	// FailOn is canonicalised by config, so an exact match is enough here.
+	selected := make(map[string]bool, len(cfg.FailOn))
+	for _, c := range cfg.FailOn {
+		selected[c] = true
+	}
+
+	var failing []string
+	for _, category := range uncovered {
+		if accepted.Contains(category) {
+			debugf("Category %s is accepted by the baseline", category)
+			continue
+		}
+		if len(selected) > 0 && !selected[category] {
+			continue
+		}
+		failing = append(failing, category)
+	}
+	return failing, nil
 }
 
 func Setup() (*Handler, error) {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/MustacheCase/zanadir/baseline"
 	"github.com/MustacheCase/zanadir/config"
 	"github.com/MustacheCase/zanadir/matcher"
 	"github.com/MustacheCase/zanadir/models"
@@ -178,4 +180,169 @@ func TestHandler_Execute_DebugMode(t *testing.T) {
 
 	// Check that the debug output contains our expected log message.
 	assert.Contains(t, out, "Starting scan for directory:")
+}
+
+// newEnforcementHandler wires mocks reporting the given categories as uncovered.
+func newEnforcementHandler(uncovered ...string) *Handler {
+	suggestions := make([]*suggester.CategorySuggestion, 0, len(uncovered))
+	for _, id := range uncovered {
+		suggestions = append(suggestions, &suggester.CategorySuggestion{ID: id, Name: id})
+	}
+
+	mockRules := new(MockRuleService)
+	mockRules.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{})
+
+	mockScanner := new(MockScanner)
+	mockScanner.On("Scan", mock.Anything).Return([]*models.Artifact{}, nil)
+
+	mockMatcher := new(MockMatcher)
+	mockMatcher.On("Match", mock.Anything, mock.Anything).Return([]*matcher.Finding{})
+
+	mockSuggester := new(MockSuggester)
+	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions)
+
+	mockOutput := new(MockOutput)
+	mockOutput.On("Response", mock.Anything, mock.Anything).Return(nil)
+
+	return &Handler{
+		RulesService:      mockRules,
+		ScanService:       mockScanner,
+		MatchService:      mockMatcher,
+		SuggestionService: mockSuggester,
+		OutputService:     mockOutput,
+	}
+}
+
+func TestEnforcementDecision(t *testing.T) {
+	tests := []struct {
+		name      string
+		uncovered []string
+		cfg       config.Config
+		wantFail  bool
+		wantIn    string
+	}{
+		{
+			name:      "no enforcement means gaps never fail",
+			uncovered: []string{"SCA", "Coverage"},
+			cfg:       config.Config{},
+			wantFail:  false,
+		},
+		{
+			name:      "enforce fails on any gap",
+			uncovered: []string{"Coverage"},
+			cfg:       config.Config{Enforce: true},
+			wantFail:  true,
+			wantIn:    "Coverage",
+		},
+		{
+			name:      "enforce passes when nothing is uncovered",
+			uncovered: nil,
+			cfg:       config.Config{Enforce: true},
+			wantFail:  false,
+		},
+		{
+			// The point of --fail-on: block on security, not performance.
+			name:      "fail-on limits enforcement to named categories",
+			uncovered: []string{"SCA", "Performance Testing"},
+			cfg:       config.Config{FailOn: []string{"SCA"}},
+			wantFail:  true,
+			wantIn:    "SCA",
+		},
+		{
+			name:      "fail-on ignores categories it does not name",
+			uncovered: []string{"Performance Testing"},
+			cfg:       config.Config{FailOn: []string{"SCA"}},
+			wantFail:  false,
+		},
+		{
+			// config canonicalises FailOn, so the handler sees exact titles.
+			name:      "fail-on matches the canonical title",
+			uncovered: []string{"SCA"},
+			cfg:       config.Config{FailOn: []string{"SCA"}},
+			wantFail:  true,
+		},
+		{
+			name:      "fail-on implies enforcement without --enforce",
+			uncovered: []string{"SCA"},
+			cfg:       config.Config{Enforce: false, FailOn: []string{"SCA"}},
+			wantFail:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newEnforcementHandler(tt.uncovered...)
+			cfg := tt.cfg
+			cfg.Dir = t.TempDir()
+
+			err := h.Execute(&cfg)
+			if !tt.wantFail {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			var enforceErr *models.EnforceError
+			assert.True(t, errors.As(err, &enforceErr), "expected an EnforceError")
+			if tt.wantIn != "" {
+				assert.Contains(t, err.Error(), tt.wantIn)
+			}
+		})
+	}
+}
+
+// A baseline lets enforcement be switched on before everything is fixed.
+func TestBaselineSuppressesAcceptedGaps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.yaml")
+	assert.NoError(t, baseline.Write(path, []string{"SCA", "Coverage"}))
+
+	h := newEnforcementHandler("SCA", "Coverage")
+	err := h.Execute(&config.Config{Dir: t.TempDir(), Enforce: true, Baseline: path})
+	assert.NoError(t, err, "every gap is in the baseline, so the scan should pass")
+}
+
+func TestBaselineStillFailsOnNewGaps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.yaml")
+	assert.NoError(t, baseline.Write(path, []string{"SCA"}))
+
+	h := newEnforcementHandler("SCA", "Secrets Detection")
+	err := h.Execute(&config.Config{Dir: t.TempDir(), Enforce: true, Baseline: path})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Secrets Detection")
+	assert.NotContains(t, err.Error(), "SCA", "an accepted gap should not be reported as failing")
+}
+
+func TestWriteBaselineRecordsCurrentGapsAndPasses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.yaml")
+
+	h := newEnforcementHandler("SCA", "Coverage")
+	err := h.Execute(&config.Config{Dir: t.TempDir(), Enforce: true, Baseline: path, WriteBaseline: true})
+	assert.NoError(t, err, "writing a baseline should not fail the scan it is derived from")
+
+	b, err := baseline.Load(path)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Coverage", "SCA"}, b.Categories)
+}
+
+func TestBaselineLoadErrorIsSurfaced(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.yaml")
+	assert.NoError(t, os.WriteFile(path, []byte("version: 99\n"), 0o600))
+
+	h := newEnforcementHandler("SCA")
+	err := h.Execute(&config.Config{Dir: t.TempDir(), Enforce: true, Baseline: path})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported version")
+}
+
+// A baseline that cannot be written must fail loudly; silently continuing would
+// leave CI enforcing against a baseline the operator believes they just wrote.
+func TestWriteBaselineReportsWriteFailure(t *testing.T) {
+	h := newEnforcementHandler("SCA")
+	cfg := &config.Config{
+		WriteBaseline: true,
+		Baseline:      filepath.Join(t.TempDir(), "no-such-dir", baseline.DefaultPath),
+	}
+
+	err := h.Execute(cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write baseline")
 }


### PR DESCRIPTION
> **Stacked PR 5 of 7.** Review and merge in order: #130 → #131 → #132 → #133 → #134 → #135 → #136. Based on #133, so the diff shown is only this PR's own changes.

# Pull Request

## Description

`--enforce` fails when **any** category is uncovered, which makes it effectively unadoptable. A real repository almost always has at least one gap, so turning enforcement on means a permanently red build. The feature exists, but nobody can switch it on.

This adds two mechanisms that compose, so enforcement becomes something a team can actually adopt incrementally.

### `--fail-on` — enforce only what you care about

```sh
zanadir scan --dir . --fail-on "SCA,Secrets Detection"
```

Block on missing SCA and secrets scanning while performance testing stays informational. It implies enforcement (no need for `--enforce` alongside) and matches category names case-insensitively.

### `--baseline` — accept today's gaps, block new ones

A baseline records the gaps a repository knowingly accepts. Those categories are still reported, they just no longer fail the scan — so enforcement can go on **before** everything is fixed, and only *new* gaps break the build.

```sh
zanadir scan --dir . --write-baseline     # generate, then commit it
zanadir scan --dir . --enforce --baseline .zanadir-baseline.yaml
```

```yaml
# zanadir baseline: categories that are uncovered but accepted.
# These are still reported; they just do not fail a scan.
# Regenerate with: zanadir scan --dir . --write-baseline
version: 1
categories:
    - Coverage
    - Performance Testing
```

Design details worth noting:

- **A missing baseline is not an error** — it means "nothing accepted yet", so a first run can't break.
- **Entries are sorted** so the committed file diffs cleanly.
- **The file carries a `version`** field, and an unknown version is rejected rather than silently misread.

### Enforcement failures now say what failed

Previously the error was deliberately swallowed:

```go
if _, ok := err.(*models.EnforceError); ok {
    // Do not print the error, just exit
    os.Exit(1)
}
```

That was survivable when enforcement was all-or-nothing, but not once `--fail-on` and baselines narrow it down — you'd get a red build with no indication of which gap caused it. Now:

```console
$ zanadir scan --dir . --enforce --baseline .zanadir-baseline.yaml
Enforcement failed: uncovered categories: SCA
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

`--enforce` alone behaves exactly as before.

## How Has This Been Tested?

```bash
go vet ./... && go test -race ./...   # all pass
golangci-lint run ./...               # 0 issues
```

`TestEnforcementDecision` is a table test over the enforcement matrix: no enforcement, `--enforce` with and without gaps, `--fail-on` selecting and ignoring, case-insensitivity, and `--fail-on` implying enforcement. Separate tests cover baseline suppression, new-gap detection, `--write-baseline` round-tripping, and a malformed baseline surfacing its error.

Verified end to end with the real binary rather than only mocks:

```console
$ zanadir scan --dir . --enforce --baseline full.yaml        ; echo $?
0
$ zanadir scan --dir . --enforce --baseline sca-removed.yaml ; echo $?
Enforcement failed: uncovered categories: SCA
1
```

## Notes for reviewers

- **Depends on #130 for two categories.** `--fail-on` and the baseline match against the category id carried on suggestions. On `main` alone, `Secrets Detection` and `License Compliance` never appear as suggestions at all because of the id mismatch, so those two names can't be selected until #130 lands. No conflict between the PRs; merge order just affects which categories are usable.
- **New `baseline` package** rather than logic inside `handler`, so the file format has one owner and is testable on its own.
- `app/app_test.go` pinned the `--enforce` help text, which said it fires "when at least one rule is met" — the inverse of what it does (it fires when a rule is *not* met). Reworded, and the test updated. The file was also unformatted on `main`; since this PR edits it, I ran `gofmt` on it (6 lines).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

