### PR TITLE
docs: add design proposals for effectiveness grading and zanadir fix

### DIFF
--- a/docs/design/001-effectiveness-grading.md
+++ b/docs/design/001-effectiveness-grading.md
@@ -1,0 +1,187 @@
+# Design: grading control effectiveness
+
+**Status:** proposal — no implementation yet
+**Scope:** how zanadir could report whether a control actually protects anything, not just whether it is present
+
+## Problem
+
+Today a category is binary: some rule matched, so the category is covered and no
+suggestion is emitted. That is the entire model, in
+[`suggester.go`](../../suggester/suggester.go):
+
+```go
+coveredCategories[f.Category] = true
+```
+
+Presence is not effectiveness. All of the following mark a category "covered"
+while protecting nothing:
+
+| Configuration | Why it does not protect |
+|---|---|
+| `continue-on-error: true` on the scanner step | The job stays green no matter what the scanner finds |
+| `trivy fs --exit-code 0` | Findings are printed, never enforced |
+| Scanner runs only on `schedule:` | Nothing is blocked at merge time |
+| `if: github.ref == 'refs/heads/main'` | Pull requests are never scanned |
+| Scanner runs only on `workflow_dispatch` | It runs when someone remembers |
+| `soft_fail: true` (tfsec, several actions) | Same as `continue-on-error` |
+| Step is in a job that is never referenced by a workflow trigger | Dead configuration |
+
+This matters more than adding rules for more tools. A repository that has
+adopted gitleaks and wired it up so it can never fail is in a *worse* position
+than one with no gitleaks at all, because everyone believes the control exists.
+Reporting "covered" there is an actively wrong answer.
+
+It is also the most defensible thing zanadir could do. Detecting whether a
+string appears in a workflow is easy to copy; modelling whether a control is
+wired up to actually block a merge is not.
+
+## Why it is not a small change
+
+The parsers currently discard everything except the tool identity. After
+[`parser/github.go`](../../parser/github.go) runs, an artifact is:
+
+```go
+type Artifact struct {
+    Name     string
+    Jobs     []*Job     // Name, Package, Version
+    Location string
+}
+```
+
+There is no representation of:
+
+- workflow triggers (`on:`)
+- branch filters
+- `continue-on-error`, at either step or job level
+- `if:` conditions
+- step arguments (`with:`, and the flags inside a `run:` command)
+- the job graph (`needs:`), so we cannot tell whether a job is reachable
+
+Every signal in the table above lives in one of those. So the parser and model
+work is the bulk of this, and the grading logic on top is comparatively small.
+
+## Proposed model
+
+Keep the binary "is the tool present" answer, and add an orthogonal
+**effectiveness** verdict to each finding:
+
+```
+enforcing    the control can fail the build on the default path
+advisory     the control runs but cannot fail the build
+partial      the control can fail the build, but not on every relevant path
+                (e.g. pushes only, not pull requests)
+unreachable  the control is configured but never runs
+```
+
+A category is then reported along three lines rather than two:
+
+- **not covered** — no tool at all (today's suggestion)
+- **covered, but weakened** — a tool exists with a verdict below `enforcing`
+- **covered** — at least one `enforcing` control
+
+The second is new output, and is the whole point of the feature.
+
+### Data model changes
+
+```go
+type Artifact struct {
+    Name     string
+    Triggers []Trigger  // new
+    Jobs     []*Job
+    Location string
+}
+
+type Trigger struct {
+    Event    string   // push, pull_request, schedule, workflow_dispatch
+    Branches []string // branch filter, empty means all
+}
+
+type Job struct {
+    Name            string
+    Package         string
+    Version         string
+    Run             string
+    ContinueOnError bool     // new
+    If              string   // new
+    Needs           []string // new
+    With            map[string]string // new
+}
+```
+
+`Run`, from the shell-step work, already exists.
+
+### Where the checks live
+
+Two options, and the choice matters for how contributors extend this.
+
+**Option A — extend the existing rule schema.** Add a `weakenedWhen` block to a
+rule in `rules/storage/*.yaml`:
+
+```yaml
+- id: "gitleaks-rule"
+  applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+  categories: ["Secrets Detection"]
+  regex: "(?i)\\bgitleaks\\b"
+  weakenedWhen:
+    - field: "Job.ContinueOnError"
+      equals: true
+      verdict: "advisory"
+    - field: "Job.Run"
+      regex: "--exit-code\\s+0"
+      verdict: "advisory"
+```
+
+Keeps everything about a tool in one place, and contributors already understand
+this file. But it grows a small expression language inside YAML, which tends to
+end badly.
+
+**Option B — generic checks independent of the tool.** Most degradations are
+tool-agnostic: `continue-on-error` weakens *any* control. Express those once,
+in Go, and let rules opt out. Far less YAML, but tool-specific flags like
+`--exit-code 0` still need somewhere to live.
+
+**Recommendation: B for the generic signals, with a narrow `weakenedWhen` for
+tool-specific flags.** Most of the value is in the generic set, and it should
+not require touching 29 rule files.
+
+## Interaction with existing features
+
+- **Enforcement** (`--fail-on`, baseline): a weakened control should be able to
+  fail a build. Probably a `--fail-on-weakened` flag, off by default, since
+  turning weak controls into failures overnight would break people.
+- **SARIF**: maps naturally. A weakened control is a `note`-level result;
+  a missing one stays `warning`.
+- **Baseline**: needs to record verdicts, not just category names, or accepting
+  a gap would also silently accept a later degradation of it.
+
+## Risks
+
+- **False positives are costly here.** `continue-on-error: true` is legitimate
+  while a team rolls a scanner out. Getting told your deliberate choice is wrong
+  is more annoying than being told about a gap. Mitigation: an ignore
+  annotation, and shipping the verdict as informational before it can fail
+  anything.
+- **The `if:` expression language is not fully analysable.** `if:` can reference
+  arbitrary context. We should only reason about a small set of recognised
+  patterns and report `unknown` otherwise, never guess.
+- **Reusable workflows and composite actions hide configuration.** A `uses:`
+  pointing at another repo is opaque. We can see the call, not what it does.
+  Should be reported as `unknown` rather than assumed effective.
+
+## Suggested phasing
+
+1. **Capture the context.** Parser and model changes only, no grading, no
+   output change. Verifiable in isolation and useful on its own.
+2. **Generic verdicts.** `continue-on-error`, trigger analysis, branch filters.
+   Surface in JSON and SARIF as informational.
+3. **Tool-specific flags.** The narrow `weakenedWhen` escape hatch.
+4. **Enforcement.** `--fail-on-weakened`, baseline records verdicts.
+
+## Open questions
+
+- Should a category with only advisory controls still produce a tool
+  suggestion, or a different message ("you have gitleaks, wire it up")? The
+  second is more useful and needs new output shape.
+- Does `unreachable` need the full `needs:` graph, or is trigger analysis
+  enough for a first version?
+- How should the table output show verdicts without becoming unreadable?

--- a/docs/design/002-zanadir-fix.md
+++ b/docs/design/002-zanadir-fix.md
@@ -1,0 +1,143 @@
+# Design: `zanadir fix`
+
+**Status:** proposal — no implementation yet
+**Scope:** generating ready-to-use CI configuration for the gaps zanadir reports
+
+## Problem
+
+A scan ends with a list of things you should have. Acting on it means leaving
+the tool, finding the action, working out where it goes in your workflow, and
+getting the YAML right. That gap between "here is what is missing" and "here is
+it fixed" is where most reports die.
+
+zanadir already knows everything needed to close it: the category, the
+suggested tool, its repository, the CI platform in use, and — after language
+detection — the ecosystem. The missing piece is a template per tool.
+
+## What it would look like
+
+```console
+$ zanadir fix --dir .
+Secrets Detection is not covered. Add to .github/workflows/security.yml:
+
+  - name: Detect secrets
+    uses: gitleaks/gitleaks-action@v2
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+$ zanadir fix --dir . --write
+Wrote .github/workflows/zanadir-suggested.yml (2 categories)
+```
+
+## The central design question: how invasive to be
+
+Three options, in increasing order of usefulness and risk.
+
+**1. Print only.** Emit snippets to stdout, never touch files. Trivial, safe,
+and leaves the copy-paste step with the user. This is most of the value for
+almost none of the risk.
+
+**2. Write a new workflow file.** Generate a self-contained
+`.github/workflows/zanadir-suggested.yml`. Never edits an existing file, so
+formatting and comments elsewhere cannot be damaged; worst case is a file the
+user deletes. Idempotent by construction — regenerate and overwrite.
+
+**3. Edit existing workflows.** Insert steps into the user's own jobs. The most
+useful and by far the most dangerous. Round-tripping YAML loses or reorders
+comments unless handled very carefully, and getting it wrong means corrupting a
+file that gates the user's deploys.
+
+**Recommendation: ship 1, then 2. Treat 3 as out of scope** until the templates
+have proven themselves. The marginal benefit over 2 is small and the failure
+mode is severe.
+
+Option 2 has a real ergonomic downside worth acknowledging: a separate workflow
+file duplicates checkout and setup steps, and runs as its own job, which is
+slower and noisier in the PR checks list than adding a step to an existing job.
+That is the price of not editing user files, and it should be stated in the
+output so nobody is surprised.
+
+## Templates
+
+Templates belong next to the catalogue they extend, keyed by tool and platform:
+
+```yaml
+# suggester/templates.yaml
+templates:
+  - tool: "Gitleaks"
+    platform: "github"
+    step: |
+      - name: Detect secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  - tool: "Gitleaks"
+    platform: "gitlab"
+    step: |
+      secret_detection:
+        image: zricethezav/gitleaks
+        script:
+          - gitleaks detect --source . --verbose
+```
+
+Not every tool needs a template. `fix` should quietly skip tools it has no
+template for rather than emitting something half-right, and the catalogue
+should be allowed to stay partial indefinitely.
+
+### Keying on tool name is fragile
+
+`tool: "Gitleaks"` is a string that must match `suggestions.yaml` exactly. This
+project has now been bitten three times by exactly that pattern — the category
+ids, the `applyOn` selectors, and the `Job.Name` selector all silently matched
+nothing. Whatever key is chosen, **validate at load time that every template
+resolves to a real suggestion, and fail loudly if not.**
+
+## Hard parts
+
+**Action version pinning.** A template hardcoding `@v2` goes stale, and worse,
+recommends an unpinned tag when security guidance increasingly says pin to a
+SHA. Options: pin to major tags and accept staleness; pin to SHAs and accept a
+maintenance burden; or resolve latest at runtime, which adds a network
+dependency to a tool that currently has none. Pinning to major tags with a
+documented refresh process is the pragmatic choice, but this deserves a
+decision rather than a default.
+
+**Which categories to fix.** Generating steps for all eight at once produces a
+large unfamiliar workflow. `fix` should probably take the same `--fail-on`-style
+category selection so users can adopt one at a time.
+
+**Secrets and configuration.** Some tools need credentials (Snyk, FOSSA,
+GitGuardian). Templates should emit the `env:` block referencing a secret and
+say plainly which secret must be created, rather than producing something that
+silently fails on first run.
+
+**Choosing among suggested tools.** Each category suggests several. `fix` has to
+pick one, and the first entry is an arbitrary default. Either take an explicit
+choice (`--tool Trivy`) or emit the default with a note about the alternatives.
+
+## Interaction with existing features
+
+- **Language detection** already narrows the tool list, so `fix` inherits a
+  sensible default for free.
+- **Baseline**: `fix` should ignore categories accepted in the baseline — the
+  user has said they do not want them.
+- A natural follow-on is opening the change as a pull request, but that pulls in
+  git and forge credentials. Out of scope here; `--write` plus the user's own
+  commit is enough.
+
+## Suggested phasing
+
+1. Template file, loader, and load-time validation. No command yet.
+2. `zanadir fix` printing snippets for uncovered categories.
+3. `--write` generating a standalone workflow file.
+4. Category and tool selection flags, baseline awareness.
+
+## Open questions
+
+- Should templates live in the binary (embedded, like `suggestions.yaml`) or be
+  overridable from the repo? Embedded is simpler; overridable helps teams with
+  house standards, which is arguably the more valuable version.
+- Is a standalone workflow file actually acceptable to users, or does the extra
+  job make it a non-starter and force option 3 sooner than we would like?
+- Should `fix` be a subcommand or a flag on `scan`? A subcommand keeps `scan`
+  read-only, which seems worth preserving.


### PR DESCRIPTION
> **Stacked PR 7 of 7.** Review and merge in order: #130 → #131 → #132 → #133 → #134 → #135 → #136. Based on #135, so the diff shown is only this PR's own changes.

# Pull Request

## Description

Design notes for the two features that are large enough to deserve agreement on the approach before any code exists. **Documents only — no behaviour change.**

### [001 — Grading control effectiveness](docs/design/001-effectiveness-grading.md)

Today a category is binary: a rule matched, so it's covered. But presence isn't effectiveness. A `gitleaks` step with `continue-on-error: true` marks secrets detection covered while blocking nothing — a *worse* position than having no scanner, because everyone believes the control exists.

The note works through the degradations that matter (`continue-on-error`, `--exit-code 0`, cron-only triggers, branch filters, `soft_fail`), proposes an orthogonal effectiveness verdict alongside the existing covered/uncovered answer, and is honest that **the bulk of the work is parser and model changes**: the parsers currently discard triggers, branch filters, `continue-on-error`, `if:` conditions and step arguments, so none of the required signals exist today.

It also argues this is the most defensible direction available — detecting whether a string appears in a workflow is easy to copy; modelling whether a control can actually block a merge is not.

### [002 — `zanadir fix`](docs/design/002-zanadir-fix.md)

Generating ready-to-use CI configuration for reported gaps. The central question is how invasive to be, and the note lays out three options and recommends the first two:

1. Print snippets to stdout — most of the value, almost none of the risk
2. Generate a standalone `zanadir-suggested.yml` — never touches existing files
3. Edit the user's existing workflows — **recommended out of scope**; the marginal benefit over 2 is small, and corrupting a file that gates someone's deploys is not a recoverable failure

It doesn't hide option 2's real downside (a separate workflow duplicates checkout/setup and adds a PR check), and works through action version pinning, tools that need secrets, and choosing among several suggested tools.

## A recurring trap, recorded in both

Both notes flag the same failure mode this repository has now hit three times — identifiers matched by exact string with nothing checking that they resolve:

- category ids vs `CategoryTitle` (#130)
- `applyOn: ["Job.Name"]` with no case in the matcher (#131)
- and template keys would be the next instance

Both designs call for load-time validation rather than repeating it.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

No code changed. `go build ./...` and `go test ./...` still pass; `git status` shows only the new `docs/` directory.

## Notes for reviewers

- These are proposals, not decisions — each ends with open questions I'd want your view on before implementing. Particularly: whether a standalone workflow file is acceptable to users or whether it forces workflow editing sooner than we'd like, and whether an advisory-only control should produce a tool suggestion or a differently-worded "you have this, wire it up" message.
- Filed under `docs/design/` with numeric prefixes on the assumption that more will follow. Happy to move them to GitHub issues instead if you'd rather not carry them in-tree.

## Checklist:

- [ ] My code follows the style guidelines of this project — n/a, documentation only
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests — n/a, no code changed
- [x] New and existing unit tests pass locally with my changes

