### PR TITLE
chore: bump zanadir-action to v1.5

### DIFF
--- a/.github/workflows/ZanadirScan.yml
+++ b/.github/workflows/ZanadirScan.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run zanadir Github action
-      uses: mustachecase/zanadir-action@v1.4
+      uses: mustachecase/zanadir-action@v1.5
       with:
         dir: .
         debug: true


### PR DESCRIPTION
Bumps the Zanadir Scan workflow from `zanadir-action@v1.4` to `@v1.5`.

`v1.5` pins the scanner image from `zanadir:0.1.2` to `zanadir:0.1.4` — the release containing shell-step detection (#131), tightened rule regexes (#132), SARIF output (#133), `--fail-on`/baseline enforcement (#134) and language-aware suggestions (#135).

This PR exists to exercise the new action version against a real scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)