### PR TITLE
fix: correct the Performance Testing category description

### DIFF
--- a/suggester/suggester_test.go
+++ b/suggester/suggester_test.go
@@ -1,6 +1,7 @@
 package suggester_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/MustacheCase/zanadir/matcher"
@@ -161,4 +162,34 @@ func TestFindSuggestionsDoesNotMutateSharedCatalogue(t *testing.T) {
 	// A second call with no language must still see the full catalogue.
 	unfiltered := s.FindSuggestions(nil, nil, nil)
 	assert.Contains(t, toolNames(findCategory(unfiltered, "Linter")), "ESLint")
+}
+
+// The catalogue is the entire user-facing text of a scan, and a copy-pasted
+// description silently misdescribes a category on every run — Performance
+// Testing shipped with Code Coverage's wording. Assert the text is distinct
+// and complete so the next paste is caught here rather than by a user.
+func TestCatalogueDescriptionsAreDistinctAndComplete(t *testing.T) {
+	s, err := suggester.NewSuggestionService()
+	assert.NoError(t, err)
+
+	all := s.FindSuggestions(nil, []string{}, nil)
+	assert.Len(t, all, len(models.CategoryTitles), "every category should be suggested when nothing is covered")
+
+	seen := make(map[string]string, len(all))
+	for _, c := range all {
+		assert.NotEmpty(t, c.Description, "category %q has no description", c.ID)
+		assert.True(t, strings.HasSuffix(c.Description, "."),
+			"category %q description should end in a period: %q", c.ID, c.Description)
+
+		if other, dup := seen[c.Description]; dup {
+			t.Errorf("categories %q and %q share a description: %q", other, c.ID, c.Description)
+		}
+		seen[c.Description] = c.ID
+
+		for _, tool := range c.Suggestions {
+			assert.NotEmpty(t, tool.Name, "category %q has a tool with no name", c.ID)
+			assert.NotEmpty(t, tool.Description, "tool %q in %q has no description", tool.Name, c.ID)
+			assert.NotEmpty(t, tool.Repository, "tool %q in %q has no repository", tool.Name, c.ID)
+		}
+	}
 }

--- a/suggester/suggestions.yaml
+++ b/suggester/suggestions.yaml
@@ -1,7 +1,7 @@
 categories:
   - id: "SCA"
     name: "SCA Open Source Tools"
-    description: "SCA tools help track open-source components and detect vulnerabilities"
+    description: "SCA tools help track open-source components and detect vulnerabilities."
     suggestions:
       - name: "Grype"
         repository: "https://github.com/anchore/grype"
@@ -38,7 +38,7 @@ categories:
 
   - id: "License Compliance"
     name: "License Compliance Tools"
-    description: "Tools for checking open-source license compliance and ensuring proper usage of dependencies"
+    description: "Tools for checking open-source license compliance and ensuring proper usage of dependencies."
     suggestions:
       - name: "FOSSA"
         repository: "https://github.com/fossas/fossa-cli"
@@ -50,7 +50,7 @@ categories:
 
       - name: "Grant"
         repository: "https://github.com/anchore/grant"
-        description: "Search an SBOM for licenses and the packages they belong to"
+        description: "Search an SBOM for licenses and the packages they belong to."
 
   - id: "End Of Life"
     name: "End-of-Life Package Checkers"
@@ -58,7 +58,7 @@ categories:
     suggestions:
       - name: "XEOL"
         repository: "https://github.com/xeol-io/xeol"
-        description: "A scanner for end-of-life (EOL) software and dependencies in container images, filesystems, and SBOMs"
+        description: "A scanner for end-of-life (EOL) software and dependencies in container images, filesystems, and SBOMs."
 
   - id: "Coverage"
     name: "Code Coverage Tools"
@@ -81,7 +81,7 @@ categories:
 
   - id: "Performance Testing"
     name: "Performance and Reliability Testing Tools"
-    description: "Tools for measuring code coverage to ensure testing completeness and software quality."
+    description: "Tools for load, stress and reliability testing, to verify a system holds up under expected and peak traffic."
     suggestions:
       - name: "k6"
         repository: "https://github.com/grafana/k6"


### PR DESCRIPTION
## Problem

`Performance and Reliability Testing Tools` shipped with **Code Coverage's description**, so every scan reporting that category told the user it was about "measuring code coverage":

```
| Performance and Reliability    | Tools for measuring code       | k6, JMeter, Gatling, Apache    |
| Testing Tools                  | coverage to ensure testing     | Bench, Artillery, BlazeMeter   |
```

## Changes

- Correct wording to describe load and reliability testing
- Add the terminal period missing from four other descriptions
- Add `TestCatalogueDescriptionsAreDistinctAndComplete`, asserting every category description is present, distinct and punctuated, and every tool has a name, description and repository

The catalogue is the entire user-facing text of a scan and nothing guarded it. Verified the new test fails on the exact duplicate this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)