### PR TITLE
feat: add --output-file to write the report to a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,31 @@ level, with the suggested tools listed in the result's help text. Results carry
 no file location, because a missing control is the absence of configuration
 rather than a defect on a particular line.
 
+#### Writing the report to a file
+
+Use `--output-file` to write the report to a path instead of stdout. This works
+with every format, and is the reliable way to produce a machine-readable report:
+redirecting stdout captures the debug log as well, so `--output sarif --debug >
+report.sarif` yields a file that is not valid JSON.
+
+```sh
+zanadir scan --dir . --output sarif --output-file zanadir.sarif
+```
+
 To publish the report from a GitHub Actions workflow:
 
 ```yaml
 - name: Run zanadir
-  run: zanadir scan --dir . --output sarif > zanadir.sarif
+  run: zanadir scan --dir . --output sarif --output-file zanadir.sarif
 
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: zanadir.sarif
 ```
+
+Uncovered categories then appear in the repository's **Security** tab alongside
+your other scanners.
 
 ## Language-Aware Suggestions
 

--- a/app/app.go
+++ b/app/app.go
@@ -54,6 +54,7 @@ func NewApp() *cobra.Command {
 	scanCmd.Flags().Bool("write-baseline", false, "Write the current uncovered categories to the baseline file and exit successfully (optional)")
 	scanCmd.Flags().Bool("debug", false, "Run the tool using debug mode (optional)")
 	scanCmd.Flags().StringP("output", "o", "table", "Output format of the tool (table, json, sarif) (optional)")
+	scanCmd.Flags().String("output-file", "", "Write the report to this file instead of stdout (optional)")
 
 	_ = scanCmd.MarkFlagRequired("dir")
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	WriteBaseline bool
 	Debug         bool
 	Output        string
+	// OutputFile writes the report to a path instead of stdout; empty means stdout.
+	OutputFile string
 }
 
 // normalizeCategories canonicalises category names and rejects unknown ones.
@@ -83,6 +85,7 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 	}
 
 	debug, _ := cmd.Flags().GetBool("debug")
+	outputFile, _ := cmd.Flags().GetString("output-file")
 	output, _ := cmd.Flags().GetString("output")
 	if output != OutputJSON && output != OutputTable && output != OutputSARIF {
 		return nil, fmt.Errorf("unsupported output format: %s (expected %s, %s or %s)", output, OutputTable, OutputJSON, OutputSARIF)
@@ -97,5 +100,6 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 		WriteBaseline:      writeBaseline,
 		Debug:              debug,
 		Output:             output,
+		OutputFile:         outputFile,
 	}, nil
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) Execute(cfg *config.Config) error {
 	suggestions := h.SuggestionService.FindSuggestions(findings, cfg.ExcludedCategories, languages)
 	debugf("Total suggestions: %d", len(suggestions))
 
-	err = h.OutputService.Response(suggestions, cfg.Output)
+	err = h.OutputService.Response(suggestions, cfg.Output, cfg.OutputFile)
 	if err != nil {
 		debugf("Output error: %v", err)
 		return err

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -48,8 +48,8 @@ func (m *MockSuggester) FindSuggestions(findings []*matcher.Finding, excludedCat
 	return args.Get(0).([]*suggester.CategorySuggestion)
 }
 
-func (m *MockOutput) Response(suggestions []*suggester.CategorySuggestion, responseType string) error {
-	args := m.Called(suggestions, responseType)
+func (m *MockOutput) Response(suggestions []*suggester.CategorySuggestion, responseType string, destPath string) error {
+	args := m.Called(suggestions, responseType, destPath)
 	return args.Error(0)
 }
 
@@ -100,7 +100,7 @@ func TestHandler_Execute(t *testing.T) {
 	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{}).Times(len(models.CategoryTitles))
 	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return(findings).Times(len(models.CategoryTitles))
 	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions, nil)
-	mockOutput.On("Response", suggestions, mockResponseType).Return(nil)
+	mockOutput.On("Response", suggestions, mockResponseType, "").Return(nil)
 
 	err := h.Execute(&config)
 
@@ -141,7 +141,7 @@ func TestHandler_Execute_WithSuggestionsAndEnforce(t *testing.T) {
 	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{}).Times(len(models.CategoryTitles))
 	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return(findings).Times(len(models.CategoryTitles))
 	mockSuggester.On("FindSuggestions", mock.Anything, mock.Anything).Return(suggestions)
-	mockOutput.On("Response", suggestions, mockResponseType).Return(nil)
+	mockOutput.On("Response", suggestions, mockResponseType, "").Return(nil)
 
 	err := h.Execute(&config)
 
@@ -171,7 +171,7 @@ func TestHandler_Execute_DebugMode(t *testing.T) {
 	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{}).Times(len(models.CategoryTitles))
 	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return(findings).Times(len(models.CategoryTitles))
 	mockSuggester.On("FindSuggestions", mock.Anything, mock.Anything).Return(suggestions)
-	mockOutput.On("Response", suggestions, mockResponseType).Return(nil)
+	mockOutput.On("Response", suggestions, mockResponseType, "").Return(nil)
 
 	out := captureOutput(func() {
 		err := NewHandler(mockRuleService, mockScanner, mockSuggester, mockMatcher, mockOutput).Execute(&cfg)
@@ -202,7 +202,7 @@ func newEnforcementHandler(uncovered ...string) *Handler {
 	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions)
 
 	mockOutput := new(MockOutput)
-	mockOutput.On("Response", mock.Anything, mock.Anything).Return(nil)
+	mockOutput.On("Response", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	return &Handler{
 		RulesService:      mockRules,

--- a/output/output.go
+++ b/output/output.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -11,9 +12,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-// Updated interface: single Response method with a response type parameter.
+// Output renders a scan result. destPath selects where the report goes: empty
+// means stdout, otherwise the report is written to that file.
 type Output interface {
-	Response(suggestions []*suggester.CategorySuggestion, responseType string) error
+	Response(suggestions []*suggester.CategorySuggestion, responseType string, destPath string) error
 }
 
 type service struct{}
@@ -44,18 +46,41 @@ func wrapText(text string, lineWidth int) string {
 	return strings.Join(lines, "\n")
 }
 
-func (s *service) Response(suggestions []*suggester.CategorySuggestion, responseType string) error {
+// destination resolves where a report is written. The returned close function
+// is always safe to call, so callers can defer it unconditionally.
+func destination(path string) (io.Writer, func(), error) {
+	if path == "" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // path is operator-supplied
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("failed to open output file %s: %w", path, err)
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+func (s *service) Response(suggestions []*suggester.CategorySuggestion, responseType string, destPath string) error {
+	w, closeDest, err := destination(destPath)
+	if err != nil {
+		return err
+	}
+	defer closeDest()
+
+	return render(w, suggestions, responseType)
+}
+
+func render(w io.Writer, suggestions []*suggester.CategorySuggestion, responseType string) error {
 	if responseType == config.OutputSARIF {
 		report, err := renderSarif(suggestions)
 		if err != nil {
 			return err
 		}
-		fmt.Println(report)
-		return nil
+		_, err = fmt.Fprintln(w, report)
+		return err
 	}
 
 	if responseType == config.OutputTable {
-		table := tablewriter.NewWriter(os.Stdout)
+		table := tablewriter.NewWriter(w)
 		table.SetHeader([]string{"Category", "Description", "Suggested Tools"})
 		table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 		table.SetCenterSeparator("|")
@@ -86,8 +111,8 @@ func (s *service) Response(suggestions []*suggester.CategorySuggestion, response
 	if err != nil {
 		return fmt.Errorf("failed to marshal suggestions: %w", err)
 	}
-	fmt.Println(string(data))
-	return nil
+	_, err = fmt.Fprintln(w, string(data))
+	return err
 }
 
 func NewOutputService() Output {

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -51,7 +52,7 @@ func TestResponse_JSONOutput(t *testing.T) {
 	suggestions := getSampleSuggestions()
 
 	out := captureStdout(func() {
-		err := service.Response(suggestions, "json")
+		err := service.Response(suggestions, "json", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -74,7 +75,7 @@ func TestResponse_TableOutput(t *testing.T) {
 	suggestions := getSampleSuggestions()
 
 	out := captureStdout(func() {
-		err := service.Response(suggestions, config.OutputTable)
+		err := service.Response(suggestions, config.OutputTable, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -91,7 +92,7 @@ func TestResponse_SARIFOutput(t *testing.T) {
 	suggestions := getSampleSuggestions()
 
 	out := captureStdout(func() {
-		err := service.Response(suggestions, config.OutputSARIF)
+		err := service.Response(suggestions, config.OutputSARIF, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -116,5 +117,66 @@ func TestResponse_SARIFOutput(t *testing.T) {
 func TestWrapTextEmptyInput(t *testing.T) {
 	if got := wrapText("   ", 10); got != "" {
 		t.Errorf("expected empty string for blank input, got %q", got)
+	}
+}
+
+// Writing to a file is what lets CI hand a SARIF report to a consumer such as
+// GitHub code scanning, so the report must land in the file and not on stdout.
+func TestResponse_WritesSARIFToFile(t *testing.T) {
+	service := NewOutputService()
+	suggestions := getSampleSuggestions()
+	path := filepath.Join(t.TempDir(), "zanadir.sarif")
+
+	out := captureStdout(func() {
+		if err := service.Response(suggestions, config.OutputSARIF, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected nothing on stdout when writing to a file, got:\n%s", out)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("report file not written: %v", err)
+	}
+	var report sarifLog
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("file is not valid SARIF: %v", err)
+	}
+	if len(report.Runs) != 1 || len(report.Runs[0].Results) != len(suggestions) {
+		t.Errorf("expected 1 run with %d results, got %d runs", len(suggestions), len(report.Runs))
+	}
+}
+
+func TestResponse_WritesTableToFile(t *testing.T) {
+	service := NewOutputService()
+	path := filepath.Join(t.TempDir(), "report.txt")
+
+	if err := service.Response(getSampleSuggestions(), config.OutputTable, path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("report file not written: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(string(data)), "suggested tools") {
+		t.Errorf("table header missing from file:\n%s", data)
+	}
+}
+
+// A report the operator asked for but never got is worse than no report.
+func TestResponse_ReportsUnwritableDestination(t *testing.T) {
+	service := NewOutputService()
+	path := filepath.Join(t.TempDir(), "no-such-dir", "zanadir.sarif")
+
+	err := service.Response(getSampleSuggestions(), config.OutputSARIF, path)
+	if err == nil {
+		t.Fatal("expected an error for an unwritable destination")
+	}
+	if !strings.Contains(err.Error(), "failed to open output file") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

SARIF landed in #133, but there was no way to get it into a file reliably.

1. **Redirecting stdout corrupts the report.** The debug log shares stdout, so the workflow the README recommended produces invalid JSON:

   ```console
   $ zanadir scan --dir . --output sarif --debug > zanadir.sarif
   $ head -1 zanadir.sarif
   [INFO] 2026/08/22 21:51:01 handler.go:33: Starting scan for directory: .
   ```

2. **The GitHub Action cannot redirect at all.** It is a Docker action whose `args` are a fixed list with no shell, so SARIF was effectively unreachable from the way most users run zanadir.

## Changes

- Rendering now goes through an `io.Writer` rather than hardcoding `os.Stdout`
- New `--output-file` flag selects a destination file; empty preserves current behaviour
- Works for every format, not just SARIF
- README documents it and explains why the redirect is unsafe

## Verification

```console
$ zanadir scan --dir . --output sarif --debug --output-file zanadir.sarif
$ head -1 zanadir.sarif
{
```

Valid SARIF 2.1.0, 1 run / 1 rule / 1 result. Tests cover writing SARIF and table to a file, stdout staying empty when a file is used, and the unwritable-destination error.

Unblocks uploading to GitHub code scanning via `github/codeql-action/upload-sarif`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)