### PR TITLE
feat: add an IaC Security category

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ case-insensitive):
 - 🧑‍💻 **Linter**: Code Linting
 - 🧪 **Unit Tests**: Automated Unit Testing
 - 🔎 **SAST**: Static Application Security Testing
+- 🏗️ **IaC Security**: Infrastructure-as-Code Misconfiguration Scanning
 
 ## Usage Examples
 

--- a/models/categories.go
+++ b/models/categories.go
@@ -12,11 +12,12 @@ const (
 	PerformanceTesting CategoryTitle = "Performance Testing"
 	UnitTests          CategoryTitle = "Unit Tests"
 	SAST               CategoryTitle = "SAST"
+	IaC                CategoryTitle = "IaC Security"
 	Table              Format        = "table"
 	JSON               Format        = "json"
 )
 
-var CategoryTitles = []CategoryTitle{SCA, Secrets, Licenses, EndOfLife, Coverage, Linter, PerformanceTesting, UnitTests, SAST}
+var CategoryTitles = []CategoryTitle{SCA, Secrets, Licenses, EndOfLife, Coverage, Linter, PerformanceTesting, UnitTests, SAST, IaC}
 
 type CategoryTitle string
 

--- a/rules/regex_test.go
+++ b/rules/regex_test.go
@@ -130,6 +130,33 @@ func TestRuleRegexPrecision(t *testing.T) {
 			shouldNotMatch: []string{"Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}", "bearer token", "-H \"Authorization: Bearer abc\""},
 		},
 		{
+			ruleID:         "checkov-rule",
+			shouldMatch:    []string{"checkov -d .", "bridgecrewio/checkov-action@master"},
+			shouldNotMatch: []string{"checkovx", "mycheckov"},
+		},
+		{
+			ruleID:         "tfsec-rule",
+			shouldMatch:    []string{"tfsec .", "aquasecurity/tfsec-action"},
+			shouldNotMatch: []string{"tfsecure", "mytfsec"},
+		},
+		{
+			ruleID:         "kics-rule",
+			shouldMatch:    []string{"kics scan -p .", "checkmarx/kics-github-action"},
+			shouldNotMatch: []string{"kicks", "nkics"},
+		},
+		{
+			// "snyk" alone is SCA; only the iac sub-command scans infrastructure.
+			ruleID:         "snyk-iac-rule",
+			shouldMatch:    []string{"snyk iac test", "snyk  iac  test ."},
+			shouldNotMatch: []string{"snyk test", "snyk code test"},
+		},
+		{
+			// "trivy" alone is SCA; the config sub-command is the misconfig scanner.
+			ruleID:         "trivy-config-rule",
+			shouldMatch:    []string{"trivy config .", "trivy  config  ./infra"},
+			shouldNotMatch: []string{"trivy fs .", "trivy image alpine"},
+		},
+		{
 			ruleID:         "codecov-rule",
 			shouldMatch:    []string{"codecov/codecov-action", "bash <(curl -s https://codecov.io/bash)"},
 			shouldNotMatch: []string{"mycodecovx"},

--- a/rules/storage/iac.yaml
+++ b/rules/storage/iac.yaml
@@ -1,0 +1,47 @@
+rules:
+  - id: "checkov-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bcheckov\\b|bridgecrewio/checkov"
+
+  - id: "tfsec-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\btfsec\\b"
+
+  - id: "terrascan-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bterrascan\\b"
+
+  - id: "kics-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bkics\\b|checkmarx/kics"
+
+  - id: "kubescape-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bkubescape\\b"
+
+  # "snyk" alone is the SCA rule; only the iac sub-command scans infrastructure.
+  - id: "snyk-iac-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bsnyk\\s+iac\\b"
+
+  # Likewise trivy: the config sub-command is the misconfiguration scanner.
+  - id: "trivy-config-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\btrivy\\s+config\\b"
+
+  - id: "cfn-nag-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bcfn[-_]nag\\b"
+
+  - id: "cfn-lint-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["IaC Security"]
+    regex: "(?i)\\bcfn-lint\\b"

--- a/suggester/suggestions.yaml
+++ b/suggester/suggestions.yaml
@@ -189,3 +189,23 @@ categories:
         description: "A static analysis security scanner for Ruby on Rails applications."
         language: "Ruby"
 
+  - id: "IaC Security"
+    name: "Infrastructure as Code Security"
+    description: "Tools that scan Terraform, CloudFormation, Kubernetes and container definitions for misconfigurations before they reach a cloud account."
+    suggestions:
+      - name: "Checkov"
+        repository: "https://github.com/bridgecrewio/checkov"
+        description: "A policy-as-code scanner covering Terraform, CloudFormation, Kubernetes, Helm and ARM templates."
+      - name: "tfsec"
+        repository: "https://github.com/aquasecurity/tfsec"
+        description: "A fast static analyser for Terraform that flags insecure configuration."
+      - name: "Terrascan"
+        repository: "https://github.com/tenable/terrascan"
+        description: "Detects compliance and security violations across infrastructure as code."
+      - name: "KICS"
+        repository: "https://github.com/Checkmarx/kics"
+        description: "Finds security vulnerabilities and misconfigurations in infrastructure code."
+      - name: "Kubescape"
+        repository: "https://github.com/kubescape/kubescape"
+        description: "Scans Kubernetes manifests and clusters against security frameworks such as NSA and MITRE."
+


### PR DESCRIPTION
Replaces #141, which I closed while trying to re-trigger checks after rebasing and GitHub then refused to reopen. Same branch, same commit, now based on `main`.

## Problem

Misconfigured infrastructure is a leading cause of cloud incidents, and zanadir had no category looking for a scanner over Terraform, CloudFormation or Kubernetes manifests.

## Changes

- New `IaC Security` category
- **9 detection rules**: Checkov, tfsec, Terrascan, KICS, Kubescape, Snyk IaC, Trivy config, cfn-nag, cfn-lint
- **5 suggestions**, deliberately untagged by language — these target infrastructure formats, not the language the repo is written in
- Regex precision tests, README updated

## Sub-command precision

Two tools already belong to another category, so the rules match the sub-command rather than the tool name:

| Invocation | Category |
|---|---|
| `trivy fs .` | SCA |
| `trivy config ./infra` | IaC Security |
| `snyk test` | SCA |
| `snyk iac test` | IaC Security |

Verified end-to-end — `trivy fs` covers SCA while leaving IaC uncovered, and `trivy config` covers IaC.

## Known limitation

Zanadir has no notion of whether a repo *contains* infrastructure code, so a repo with no Terraform will still be told to add Checkov. That is consistent with how every other category behaves today, but IaC makes it more visible. Gating a category on repository content would be a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)