### PR TITLE
feat: lead the table with a result summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,26 @@ zanadir scan --dir . --output table
 
 **Sample Output:**
 ```
+1 category needs attention:
+
 |--------------------------------|--------------------------------|-------------------|
 |            CATEGORY            |          DESCRIPTION           |  SUGGESTED TOOLS  |
 |--------------------------------|--------------------------------|-------------------|
-| Performance and Reliability    | Tools for measuring code       | k6, JMeter,       |
-| Testing Tools                  | coverage to ensure testing     | Gatling, Apache   |
-|                                | completeness and software      | Bench, Artillery, |
-|                                | quality.                       | BlazeMeter        |
+| Performance and Reliability    | Tools for load, stress and     | k6, JMeter,       |
+| Testing Tools                  | reliability testing, to verify | Gatling, Apache   |
+|                                | a system holds up under        | Bench, Artillery, |
+|                                | expected and peak traffic.     | BlazeMeter        |
 |--------------------------------|--------------------------------|-------------------|
 ```
+
+When nothing is missing, the scan says so rather than printing an empty table:
+
+```
+All categories are covered - no suggestions.
+```
+
+The headline is bold on an interactive terminal. Colour is omitted when the
+output is piped or written with `--output-file`, and when `NO_COLOR` is set.
 
 #### JSON Output
 

--- a/output/output.go
+++ b/output/output.go
@@ -48,6 +48,51 @@ func wrapText(text string, lineWidth int) string {
 
 // destination resolves where a report is written. The returned close function
 // is always safe to call, so callers can defer it unconditionally.
+// ANSI styling is applied only to the lines around the table, never inside it:
+// tablewriter measures cell width in runes and would misalign every column if
+// escape codes were counted as content.
+const (
+	ansiReset = "\x1b[0m"
+	ansiBold  = "\x1b[1m"
+	ansiGreen = "\x1b[32m"
+)
+
+// useColour reports whether w is an interactive terminal that wants colour.
+// A file or a pipe gets none, so a redirected report stays free of escapes.
+func useColour(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func paint(enabled bool, style, text string) string {
+	if !enabled {
+		return text
+	}
+	return style + text + ansiReset
+}
+
+// headline describes the result before the detail, so the reader knows the
+// scale of what follows — and so a clean repository says so explicitly rather
+// than rendering an empty table.
+func headline(count int) string {
+	if count == 0 {
+		return "All categories are covered - no suggestions."
+	}
+	if count == 1 {
+		return "1 category needs attention:"
+	}
+	return fmt.Sprintf("%d categories need attention:", count)
+}
+
+// destination resolves where a report is written. The returned close function
+// is always safe to call, so callers can defer it unconditionally.
 func destination(path string) (io.Writer, func(), error) {
 	if path == "" {
 		return os.Stdout, func() {}, nil
@@ -80,6 +125,17 @@ func render(w io.Writer, suggestions []*suggester.CategorySuggestion, responseTy
 	}
 
 	if responseType == config.OutputTable {
+		colour := useColour(w)
+
+		if len(suggestions) == 0 {
+			_, err := fmt.Fprintln(w, paint(colour, ansiGreen, headline(0)))
+			return err
+		}
+
+		if _, err := fmt.Fprintf(w, "%s\n\n", paint(colour, ansiBold, headline(len(suggestions)))); err != nil {
+			return err
+		}
+
 		table := tablewriter.NewWriter(w)
 		table.SetHeader([]string{"Category", "Description", "Suggested Tools"})
 		table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -269,5 +270,71 @@ func TestResponse_MachineFormatsHaveNoHeadline(t *testing.T) {
 		if strings.Contains(out, "need attention") {
 			t.Errorf("%s output must not contain the human headline", format)
 		}
+	}
+}
+
+// failingWriter reports an error on every write, standing in for a full disk or
+// a closed pipe.
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+func TestUseColour(t *testing.T) {
+	t.Run("not a file", func(t *testing.T) {
+		if useColour(&bytes.Buffer{}) {
+			t.Error("a plain writer is not a terminal")
+		}
+	})
+
+	t.Run("regular file", func(t *testing.T) {
+		f, err := os.Create(filepath.Join(t.TempDir(), "out.txt"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = f.Close() }()
+
+		if useColour(f) {
+			t.Error("a regular file is not a terminal")
+		}
+	})
+
+	t.Run("NO_COLOR wins over everything", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+		if useColour(os.Stdout) {
+			t.Error("NO_COLOR must suppress colour even on a terminal")
+		}
+	})
+}
+
+func TestPaint(t *testing.T) {
+	if got := paint(false, ansiBold, "plain"); got != "plain" {
+		t.Errorf("disabled paint should not wrap: %q", got)
+	}
+	if got := paint(true, ansiBold, "loud"); got != ansiBold+"loud"+ansiReset {
+		t.Errorf("enabled paint should wrap in the style: %q", got)
+	}
+}
+
+// A report that cannot be written must surface the failure rather than
+// reporting success on output nobody received.
+func TestRenderPropagatesWriteErrors(t *testing.T) {
+	boom := errors.New("disk full")
+	w := failingWriter{err: boom}
+
+	for _, format := range []string{config.OutputTable, config.OutputSARIF, "json"} {
+		t.Run(format, func(t *testing.T) {
+			err := render(w, getSampleSuggestions(), format)
+			if !errors.Is(err, boom) {
+				t.Errorf("expected the write error to propagate, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRenderPropagatesWriteErrorOnAllClear(t *testing.T) {
+	boom := errors.New("disk full")
+
+	if err := render(failingWriter{err: boom}, nil, config.OutputTable); !errors.Is(err, boom) {
+		t.Errorf("expected the write error to propagate, got %v", err)
 	}
 }

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -180,3 +180,94 @@ func TestResponse_ReportsUnwritableDestination(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// A clean repository used to render an empty table: three border lines and a
+// header row with no body, which reads as a bug rather than a pass.
+func TestResponse_TableStatesWhenNothingToSuggest(t *testing.T) {
+	service := NewOutputService()
+
+	out := captureStdout(func() {
+		if err := service.Response(nil, config.OutputTable, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "All categories are covered") {
+		t.Errorf("expected an explicit all-clear, got:\n%q", out)
+	}
+	if strings.Contains(out, "CATEGORY") || strings.Contains(out, "|---") {
+		t.Errorf("expected no table when there is nothing to show, got:\n%s", out)
+	}
+}
+
+func TestResponse_TableLeadsWithACount(t *testing.T) {
+	service := NewOutputService()
+
+	out := captureStdout(func() {
+		if err := service.Response(getSampleSuggestions(), config.OutputTable, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.HasPrefix(out, "2 categories need attention:") {
+		t.Errorf("expected the count to lead the output, got:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "suggested tools") {
+		t.Errorf("table should still render below the headline:\n%s", out)
+	}
+}
+
+func TestHeadlineIsGrammatical(t *testing.T) {
+	for count, want := range map[int]string{
+		0: "All categories are covered - no suggestions.",
+		1: "1 category needs attention:",
+		2: "2 categories need attention:",
+	} {
+		if got := headline(count); got != want {
+			t.Errorf("headline(%d) = %q, want %q", count, got, want)
+		}
+	}
+}
+
+// Escape codes in a redirected report would corrupt it for any consumer.
+func TestResponse_NoColourWhenNotATerminal(t *testing.T) {
+	service := NewOutputService()
+	path := filepath.Join(t.TempDir(), "report.txt")
+
+	if err := service.Response(getSampleSuggestions(), config.OutputTable, path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("report not written: %v", err)
+	}
+	if bytes.Contains(data, []byte("\x1b[")) {
+		t.Errorf("file report contains ANSI escapes:\n%q", data)
+	}
+
+	out := captureStdout(func() {
+		_ = service.Response(getSampleSuggestions(), config.OutputTable, "")
+	})
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("piped stdout contains ANSI escapes:\n%q", out)
+	}
+}
+
+// The machine formats must not gain a human headline.
+func TestResponse_MachineFormatsHaveNoHeadline(t *testing.T) {
+	service := NewOutputService()
+
+	for _, format := range []string{"json", config.OutputSARIF} {
+		out := captureStdout(func() {
+			if err := service.Response(getSampleSuggestions(), format, ""); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		if !strings.HasPrefix(strings.TrimSpace(out), "[") && !strings.HasPrefix(strings.TrimSpace(out), "{") {
+			t.Errorf("%s output should start with its own payload, got:\n%.80s", format, out)
+		}
+		if strings.Contains(out, "need attention") {
+			t.Errorf("%s output must not contain the human headline", format)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A scan with nothing to report rendered **an empty table** — the best possible outcome looked like a bug:

```
|----------|-------------|-----------------|
| CATEGORY | DESCRIPTION | SUGGESTED TOOLS |
|----------|-------------|-----------------|
```

And a scan *with* findings gave no sense of scale before the detail.

## After

```
All categories are covered - no suggestions.
```

```
2 categories need attention:

|---------------------|--------------------------------|-----------------------------|
|      CATEGORY       |          DESCRIPTION           |       SUGGESTED TOOLS       |
...
```

## Colour

The headline is bold on an interactive terminal. Colour is decided **from the writer**, so:

- piped output → no escapes
- `--output-file` → no escapes
- `NO_COLOR` set → no escapes

Nothing inside the table is styled, deliberately: tablewriter measures cell width in runes and would misalign every column if escape codes counted as content.

## Scope

- JSON and SARIF are byte-identical, with a test asserting the headline never reaches them
- No new dependency — TTY detection is `os.File.Stat()` + `os.ModeCharDevice`
- Terminal-width-aware columns are **not** included; that needs `x/term` or platform-specific ioctl code, and adding a dependency to a supply-chain security tool deserves its own discussion

README sample output updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)