### PR TITLE
fix: detect unit tests run from shell steps

### DIFF
--- a/rules/regex_test.go
+++ b/rules/regex_test.go
@@ -161,6 +161,23 @@ func TestRuleRegexPrecision(t *testing.T) {
 			shouldMatch:    []string{"codecov/codecov-action", "bash <(curl -s https://codecov.io/bash)"},
 			shouldNotMatch: []string{"mycodecovx"},
 		},
+		{
+			// Shell text is free-form: a bare \btests?\b would count
+			// `if test -f`, `test -z` and test.example.com as coverage.
+			ruleID: "unit-test-command-rule",
+			shouldMatch: []string{
+				"go test ./...", "go test -race -cover ./...", "npm test", "npm run test",
+				"yarn test", "pnpm run test", "pytest -q", "cargo test --all",
+				"dotnet test", "mvn -B verify test", "gradle clean test",
+				"bundle exec rspec", "npx jest --ci", "mocha spec/", "vitest run", "tox -e py311",
+			},
+			shouldNotMatch: []string{
+				"if test -f go.mod; then echo yes; fi", `test -z "$VAR" && exit 1`,
+				"curl https://test.example.com", `echo "testing the build"`,
+				"go build ./...", "go vet ./...", "npm run build", "docker build -t app:test .",
+				"latest", "deploy-latest",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/rules/storage/unit-tests.yaml
+++ b/rules/storage/unit-tests.yaml
@@ -3,3 +3,16 @@ rules:
     applyOn: ["Artifact.Name", "Job.Name"]
     categories: ["Unit Tests"]
     regex: "(?i)\\btests?\\b"
+
+  # The rule above matches a job or workflow *named* "test". A job that simply
+  # runs the suite from a shell step was missed entirely, so a repository whose
+  # CI runs `go test ./...` was told it had no unit testing.
+  #
+  # Shell text cannot be matched with a bare \btests?\b: `if test -f`,
+  # `test -z "$VAR"` and even `test.example.com` would all count as coverage.
+  # Match the runner invocations instead.
+  - id: "unit-test-command-rule"
+    applyOn: ["Job.Run"]
+    categories: ["Unit Tests"]
+    regex: "(?i)\\b(?:go|cargo|dotnet)\\s+test\\b|\\b(?:npm|yarn|pnpm)\\s+(?:run\\s+)?test\\b|\\b(?:pytest|rspec|phpunit|jest|mocha|vitest|ctest|tox)\\b|\\bmvn\\s[^\\n]*\\btest\\b|\\bgradle\\s[^\\n]*\\btest\\b|\\bbundle\\s+exec\\s+rspec\\b"
+


### PR DESCRIPTION
## Problem

`unit-test-rule` only inspected `Artifact.Name` and `Job.Name`, so being "covered" depended on a workflow or job being **named** `test`. A repository whose CI runs `go test ./...` from a step inside a job named `build` was reported as having no unit testing — and offered JUnit and pytest.

Every other category picked up `Job.Run` in #131. This one was left behind.

## Why not just add `Job.Run` to the existing rule

Its pattern is a bare `\btests?\b`. Against free-form shell that matches:

| Text | |
|---|---|
| `if test -f go.mod; then …` | POSIX `test` builtin |
| `test -z "$VAR" && exit 1` | same |
| `curl https://test.example.com` | substring in a hostname |

That trades one false negative for three false positives — and a false "covered" is the worse failure, since the user is told a control exists when it does not.

## Changes

A second rule scoped to `Job.Run` matching runner invocations: `go`/`cargo`/`dotnet test`, `npm`/`yarn`/`pnpm test`, `pytest`, `rspec`, `phpunit`, `jest`, `mocha`, `vitest`, `ctest`, `tox`, plus the `mvn … test` and `gradle … test` forms. The original name-based rule is unchanged.

16 should-match and 10 should-not-match cases added to `TestRuleRegexPrecision`.

## Verification

- CI running `go test -race ./...` in a job named `compile` → Unit Tests **covered**
- CI running `if test -f go.mod; then go build ./...; fi` → Unit Tests **still uncovered**

## Note

This will flip Unit Tests from uncovered to covered for many repositories, including this one. That is the point — the previous answer was wrong — but it does mean one fewer suggestion in the default output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)