### PR TITLE
chore: publish zanadir's own scan to code scanning

### DIFF
--- a/.github/workflows/ZanadirScan.yml
+++ b/.github/workflows/ZanadirScan.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   zanadir-scan:
@@ -18,9 +19,16 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run zanadir Github action
-      uses: mustachecase/zanadir-action@v1.5
+      uses: mustachecase/zanadir-action@v1.6
       with:
         dir: .
         debug: true
         enforce: false
-        output: table
+        output: sarif
+        output-file: zanadir.sarif
+
+    - name: Upload zanadir SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: zanadir.sarif
+        category: zanadir

--- a/.github/workflows/ZanadirScan.yml
+++ b/.github/workflows/ZanadirScan.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run zanadir Github action
-      uses: mustachecase/zanadir-action@v1.7
+      uses: mustachecase/zanadir-action@v1.8
       with:
         dir: .
         debug: true

--- a/.github/workflows/ZanadirScan.yml
+++ b/.github/workflows/ZanadirScan.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run zanadir Github action
-      uses: mustachecase/zanadir-action@v1.6
+      uses: mustachecase/zanadir-action@v1.7
       with:
         dir: .
         debug: true


### PR DESCRIPTION
Bumps this repository to [`zanadir-action@v1.6`](https://github.com/MustacheCase/zanadir-action/releases/tag/v1.6) (running zanadir `0.2.0`) and switches its own scan from a table in the job log to SARIF uploaded to code scanning.

## Why

The scan output was visible only to whoever opened the job log. As SARIF it lands in the **Security** tab, where it sits alongside the other scanners and persists across runs.

It also dogfoods the feature chain we just shipped — `--output-file` (#139) → action `output-file` input (zanadir-action#4) → `upload-sarif` — end to end, in the repo that owns it.

## Changes

- `zanadir-action@v1.5` → `@v1.6`
- `output: table` → `output: sarif` + `output-file: zanadir.sarif`
- New `Upload zanadir SARIF` step using `github/codeql-action/upload-sarif@v3`, tagged `category: zanadir` so it does not collide with the CodeQL results already uploaded
- `security-events: write` added, which `upload-sarif` requires

`enforce` stays `false`, so this cannot fail the build.

## Expected result

The scan currently reports 2 uncovered categories, so expect 2 `warning`-level alerts in the Security tab attributed to zanadir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)