### PR TITLE
fix: make --output-file reports readable by other users

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -97,7 +97,11 @@ func destination(path string) (io.Writer, func(), error) {
 	if path == "" {
 		return os.Stdout, func() {}, nil
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // path is operator-supplied
+	// 0644, not 0600: a report exists to be read by something else. The Docker
+	// action runs as root, and an owner-only file is unreadable by the runner
+	// user in the next step, which is how upload-sarif came to fail with
+	// EACCES. The content is a list of absent tooling, not a secret.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644) //nolint:gosec // operator-supplied path; a report is world-readable by design
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("failed to open output file %s: %w", path, err)
 	}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -338,3 +338,24 @@ func TestRenderPropagatesWriteErrorOnAllClear(t *testing.T) {
 		t.Errorf("expected the write error to propagate, got %v", err)
 	}
 }
+
+// A report is written to be consumed by another process, often another user:
+// the Docker action runs as root while the following step runs as the runner
+// user. An owner-only report is unreadable there, which broke SARIF upload.
+func TestResponse_ReportIsReadableByOthers(t *testing.T) {
+	service := NewOutputService()
+	path := filepath.Join(t.TempDir(), "zanadir.sarif")
+
+	if err := service.Response(getSampleSuggestions(), config.OutputSARIF, path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("report not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o044 == 0 {
+		t.Errorf("report mode %#o is owner-only; another user cannot read it "+
+			"(if this fails locally, check for a restrictive umask)", perm)
+	}
+}


### PR DESCRIPTION
## The bug

`--output-file` created the report with mode `0600`. Inside the Docker action the scan runs as **root**, so the file landed root-owned and owner-only — and the next step, running as the `runner` user, could not read it:

```
##[error]Invalid SARIF. JSON syntax error: EACCES: permission denied, open 'zanadir.sarif'
```

Which is the whole reason `--output-file` exists. Found by dogfooding it in #145, on the first real run through the action.

## The fix

Create the report `0644`.

`0600` was chosen to satisfy gosec, but it is the wrong answer for a file whose entire purpose is to be handed to another process. The content is a list of tooling a repository *lacks* — not a secret. The baseline file keeps `0600`, since it is written for the same user to commit rather than passed to another process.

## Test

`TestResponse_ReportIsReadableByOthers` asserts the report is not owner-only. Verified it fails on the old behaviour:

```
report mode 0600 is owner-only; another user cannot read it
```

## Follow-on

This makes the SARIF → code-scanning path in zanadir-action v1.6 non-functional, so it wants a `0.2.1` release and an action `v1.7` pinning it. #145 is blocked until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)