### PR TITLE
fix: anchor SARIF results at a CI configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ it lets uncovered categories show up in GitHub's Security tab, and in any other
 SARIF-consuming platform, alongside your other scanners.
 
 Each uncovered category becomes one SARIF rule and one result at `warning`
-level, with the suggested tools listed in the result's help text. Results carry
-no file location, because a missing control is the absence of configuration
-rather than a defect on a particular line.
+level, with the suggested tools listed in the result's help text. Results are
+anchored at a CI configuration file — the place the missing tool would be
+added. A missing control is not a defect on a particular line, but every SARIF
+consumer expects a location, and GitHub code scanning rejects a report whose
+results have none.
 
 #### Writing the report to a file
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -42,8 +42,6 @@ func TestScanRepo(t *testing.T) {
 	assert.NotNil(t, err, "scanRepo should return an error when handler setup fails")
 }
 
-// Enforcement failures are an expected outcome, not a crash: they belong on
-// stderr with the offending categories named.
 func TestScanErrorReportRoutesEnforcementToStderr(t *testing.T) {
 	w, msg := scanErrorReport(models.NewEnforceError("uncovered categories: SCA"))
 
@@ -60,7 +58,6 @@ func TestScanErrorReportRoutesOperationalErrorToStdout(t *testing.T) {
 	assert.Contains(t, msg, "handler setup failed")
 }
 
-// A wrapped enforcement failure is still an enforcement failure.
 func TestScanErrorReportUnwrapsEnforceError(t *testing.T) {
 	wrapped := fmt.Errorf("execute: %w", models.NewEnforceError("uncovered categories: Coverage"))
 

--- a/baseline/baseline_test.go
+++ b/baseline/baseline_test.go
@@ -79,8 +79,6 @@ func TestNilBaselineContainsNothing(t *testing.T) {
 	assert.False(t, b.Contains("SCA"))
 }
 
-// A directory is readable-but-not-a-file: distinct from "absent", and must not
-// be mistaken for an empty baseline.
 func TestLoadReportsUnreadablePath(t *testing.T) {
 	_, err := baseline.Load(t.TempDir())
 	assert.Error(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -170,7 +170,6 @@ func TestCreateConfigNormalizesExcludedCategories(t *testing.T) {
 	assert.Equal(t, []string{"SCA"}, cfg.ExcludedCategories)
 }
 
-// --write-baseline without --baseline must still land somewhere predictable.
 func TestCreateConfigDefaultsBaselinePathForWrite(t *testing.T) {
 	cmd := newScanCmd(t.TempDir(), nil)
 	assert.NoError(t, cmd.Flags().Set("write-baseline", "true"))

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -25,12 +25,8 @@ type Handler struct {
 	OutputService     output.Output
 }
 
-// sarifAnchor picks the CI configuration file that SARIF results point at.
-// Every SARIF consumer expects a location, and GitHub code scanning rejects a
-// report whose results have none, so anchor them at the file where the missing
-// tooling would be added. The path must be repository-relative for the alert to
-// resolve; if it cannot be made relative, the absolute path is skipped rather
-// than emitted, since a wrong location is worse than none.
+// sarifAnchor returns a repo-relative CI file for SARIF results to point at.
+// A path outside the scan directory is skipped: worse than no location.
 func sarifAnchor(dir string, artifacts []*models.Artifact) string {
 	for _, a := range artifacts {
 		if a == nil || a.Location == "" {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/MustacheCase/zanadir/baseline"
@@ -22,6 +23,26 @@ type Handler struct {
 	MatchService      matcher.Matcher
 	SuggestionService suggester.Suggester
 	OutputService     output.Output
+}
+
+// sarifAnchor picks the CI configuration file that SARIF results point at.
+// Every SARIF consumer expects a location, and GitHub code scanning rejects a
+// report whose results have none, so anchor them at the file where the missing
+// tooling would be added. The path must be repository-relative for the alert to
+// resolve; if it cannot be made relative, the absolute path is skipped rather
+// than emitted, since a wrong location is worse than none.
+func sarifAnchor(dir string, artifacts []*models.Artifact) string {
+	for _, a := range artifacts {
+		if a == nil || a.Location == "" {
+			continue
+		}
+		rel, err := filepath.Rel(dir, a.Location)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		return filepath.ToSlash(rel)
+	}
+	return ""
 }
 
 func (h *Handler) Execute(cfg *config.Config) error {
@@ -52,7 +73,12 @@ func (h *Handler) Execute(cfg *config.Config) error {
 	suggestions := h.SuggestionService.FindSuggestions(findings, cfg.ExcludedCategories, languages)
 	debugf("Total suggestions: %d", len(suggestions))
 
-	err = h.OutputService.Response(suggestions, cfg.Output, cfg.OutputFile)
+	err = h.OutputService.Response(output.Report{
+		Suggestions: suggestions,
+		Format:      cfg.Output,
+		DestPath:    cfg.OutputFile,
+		Anchor:      sarifAnchor(cfg.Dir, artifacts),
+	})
 	if err != nil {
 		debugf("Output error: %v", err)
 		return err

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MustacheCase/zanadir/config"
 	"github.com/MustacheCase/zanadir/matcher"
 	"github.com/MustacheCase/zanadir/models"
+	"github.com/MustacheCase/zanadir/output"
 	"github.com/MustacheCase/zanadir/rules"
 	"github.com/MustacheCase/zanadir/suggester"
 	"github.com/stretchr/testify/assert"
@@ -48,8 +49,8 @@ func (m *MockSuggester) FindSuggestions(findings []*matcher.Finding, excludedCat
 	return args.Get(0).([]*suggester.CategorySuggestion)
 }
 
-func (m *MockOutput) Response(suggestions []*suggester.CategorySuggestion, responseType string, destPath string) error {
-	args := m.Called(suggestions, responseType, destPath)
+func (m *MockOutput) Response(report output.Report) error {
+	args := m.Called(report)
 	return args.Error(0)
 }
 
@@ -100,7 +101,7 @@ func TestHandler_Execute(t *testing.T) {
 	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{}).Times(len(models.CategoryTitles))
 	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return(findings).Times(len(models.CategoryTitles))
 	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions, nil)
-	mockOutput.On("Response", suggestions, mockResponseType, "").Return(nil)
+	mockOutput.On("Response", mock.Anything).Return(nil)
 
 	err := h.Execute(&config)
 
@@ -141,7 +142,7 @@ func TestHandler_Execute_WithSuggestionsAndEnforce(t *testing.T) {
 	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{}).Times(len(models.CategoryTitles))
 	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return(findings).Times(len(models.CategoryTitles))
 	mockSuggester.On("FindSuggestions", mock.Anything, mock.Anything).Return(suggestions)
-	mockOutput.On("Response", suggestions, mockResponseType, "").Return(nil)
+	mockOutput.On("Response", mock.Anything).Return(nil)
 
 	err := h.Execute(&config)
 
@@ -171,7 +172,7 @@ func TestHandler_Execute_DebugMode(t *testing.T) {
 	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{}).Times(len(models.CategoryTitles))
 	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return(findings).Times(len(models.CategoryTitles))
 	mockSuggester.On("FindSuggestions", mock.Anything, mock.Anything).Return(suggestions)
-	mockOutput.On("Response", suggestions, mockResponseType, "").Return(nil)
+	mockOutput.On("Response", mock.Anything).Return(nil)
 
 	out := captureOutput(func() {
 		err := NewHandler(mockRuleService, mockScanner, mockSuggester, mockMatcher, mockOutput).Execute(&cfg)
@@ -202,7 +203,7 @@ func newEnforcementHandler(uncovered ...string) *Handler {
 	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions)
 
 	mockOutput := new(MockOutput)
-	mockOutput.On("Response", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockOutput.On("Response", mock.Anything).Return(nil)
 
 	return &Handler{
 		RulesService:      mockRules,
@@ -345,4 +346,45 @@ func TestWriteBaselineReportsWriteFailure(t *testing.T) {
 	err := h.Execute(cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write baseline")
+}
+
+func TestSarifAnchor(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string
+		artifacts []*models.Artifact
+		want      string
+	}{
+		{
+			name:      "repository-relative path",
+			dir:       "/repo",
+			artifacts: []*models.Artifact{{Location: "/repo/.github/workflows/ci.yml"}},
+			want:      ".github/workflows/ci.yml",
+		},
+		{
+			name:      "skips entries without a location",
+			dir:       "/repo",
+			artifacts: []*models.Artifact{{Location: ""}, {Location: "/repo/.gitlab-ci.yml"}},
+			want:      ".gitlab-ci.yml",
+		},
+		{
+			// A path outside the repository would not resolve for a consumer.
+			name:      "skips paths outside the scanned directory",
+			dir:       "/repo",
+			artifacts: []*models.Artifact{{Location: "/elsewhere/ci.yml"}},
+			want:      "",
+		},
+		{
+			name:      "no artifacts",
+			dir:       "/repo",
+			artifacts: nil,
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sarifAnchor(tt.dir, tt.artifacts))
+		})
+	}
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -334,8 +334,6 @@ func TestBaselineLoadErrorIsSurfaced(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported version")
 }
 
-// A baseline that cannot be written must fail loudly; silently continuing would
-// leave CI enforcing against a baseline the operator believes they just wrote.
 func TestWriteBaselineReportsWriteFailure(t *testing.T) {
 	h := newEnforcementHandler("SCA")
 	cfg := &config.Config{

--- a/output/output.go
+++ b/output/output.go
@@ -12,10 +12,24 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-// Output renders a scan result. destPath selects where the report goes: empty
-// means stdout, otherwise the report is written to that file.
+// Report is everything needed to render one scan result. It is a struct rather
+// than a parameter list because three of its fields are strings and would be
+// trivial to transpose at a call site.
+type Report struct {
+	// Suggestions are the uncovered categories, in report order.
+	Suggestions []*suggester.CategorySuggestion
+	// Format is one of the config.Output* values.
+	Format string
+	// DestPath writes the report to a file; empty means stdout.
+	DestPath string
+	// Anchor is a repository-relative CI configuration path that SARIF results
+	// point at. Empty omits locations, which GitHub code scanning rejects.
+	Anchor string
+}
+
+// Output renders a scan result.
 type Output interface {
-	Response(suggestions []*suggester.CategorySuggestion, responseType string, destPath string) error
+	Response(report Report) error
 }
 
 type service struct{}
@@ -108,23 +122,24 @@ func destination(path string) (io.Writer, func(), error) {
 	return f, func() { _ = f.Close() }, nil
 }
 
-func (s *service) Response(suggestions []*suggester.CategorySuggestion, responseType string, destPath string) error {
-	w, closeDest, err := destination(destPath)
+func (s *service) Response(report Report) error {
+	w, closeDest, err := destination(report.DestPath)
 	if err != nil {
 		return err
 	}
 	defer closeDest()
 
-	return render(w, suggestions, responseType)
+	return render(w, report)
 }
 
-func render(w io.Writer, suggestions []*suggester.CategorySuggestion, responseType string) error {
+func render(w io.Writer, report Report) error {
+	suggestions, responseType := report.Suggestions, report.Format
 	if responseType == config.OutputSARIF {
-		report, err := renderSarif(suggestions)
+		sarifReport, err := renderSarif(suggestions, report.Anchor)
 		if err != nil {
 			return err
 		}
-		_, err = fmt.Fprintln(w, report)
+		_, err = fmt.Fprintln(w, sarifReport)
 		return err
 	}
 

--- a/output/output.go
+++ b/output/output.go
@@ -12,22 +12,14 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-// Report is everything needed to render one scan result. It is a struct rather
-// than a parameter list because three of its fields are strings and would be
-// trivial to transpose at a call site.
+// Report is one scan result to render.
 type Report struct {
-	// Suggestions are the uncovered categories, in report order.
 	Suggestions []*suggester.CategorySuggestion
-	// Format is one of the config.Output* values.
-	Format string
-	// DestPath writes the report to a file; empty means stdout.
-	DestPath string
-	// Anchor is a repository-relative CI configuration path that SARIF results
-	// point at. Empty omits locations, which GitHub code scanning rejects.
-	Anchor string
+	Format      string
+	DestPath    string // empty means stdout
+	Anchor      string // repo-relative path SARIF results point at
 }
 
-// Output renders a scan result.
 type Output interface {
 	Response(report Report) error
 }
@@ -60,19 +52,14 @@ func wrapText(text string, lineWidth int) string {
 	return strings.Join(lines, "\n")
 }
 
-// destination resolves where a report is written. The returned close function
-// is always safe to call, so callers can defer it unconditionally.
-// ANSI styling is applied only to the lines around the table, never inside it:
-// tablewriter measures cell width in runes and would misalign every column if
-// escape codes were counted as content.
+// Only the lines around the table are styled: tablewriter measures width in
+// runes and escape codes would misalign every column.
 const (
 	ansiReset = "\x1b[0m"
 	ansiBold  = "\x1b[1m"
 	ansiGreen = "\x1b[32m"
 )
 
-// useColour reports whether w is an interactive terminal that wants colour.
-// A file or a pipe gets none, so a redirected report stays free of escapes.
 func useColour(w io.Writer) bool {
 	if os.Getenv("NO_COLOR") != "" {
 		return false
@@ -92,9 +79,6 @@ func paint(enabled bool, style, text string) string {
 	return style + text + ansiReset
 }
 
-// headline describes the result before the detail, so the reader knows the
-// scale of what follows — and so a clean repository says so explicitly rather
-// than rendering an empty table.
 func headline(count int) string {
 	if count == 0 {
 		return "All categories are covered - no suggestions."
@@ -105,16 +89,13 @@ func headline(count int) string {
 	return fmt.Sprintf("%d categories need attention:", count)
 }
 
-// destination resolves where a report is written. The returned close function
-// is always safe to call, so callers can defer it unconditionally.
+// The returned close function is always safe to call.
 func destination(path string) (io.Writer, func(), error) {
 	if path == "" {
 		return os.Stdout, func() {}, nil
 	}
-	// 0644, not 0600: a report exists to be read by something else. The Docker
-	// action runs as root, and an owner-only file is unreadable by the runner
-	// user in the next step, which is how upload-sarif came to fail with
-	// EACCES. The content is a list of absent tooling, not a secret.
+	// 0644: the action runs as root and the next step, as another user, must
+	// read the report. It lists absent tooling, not secrets.
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644) //nolint:gosec // operator-supplied path; a report is world-readable by design
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("failed to open output file %s: %w", path, err)

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -53,7 +53,7 @@ func TestResponse_JSONOutput(t *testing.T) {
 	suggestions := getSampleSuggestions()
 
 	out := captureStdout(func() {
-		err := service.Response(suggestions, "json", "")
+		err := service.Response(Report{Suggestions: suggestions, Format: "json"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -76,7 +76,7 @@ func TestResponse_TableOutput(t *testing.T) {
 	suggestions := getSampleSuggestions()
 
 	out := captureStdout(func() {
-		err := service.Response(suggestions, config.OutputTable, "")
+		err := service.Response(Report{Suggestions: suggestions, Format: config.OutputTable})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -93,7 +93,7 @@ func TestResponse_SARIFOutput(t *testing.T) {
 	suggestions := getSampleSuggestions()
 
 	out := captureStdout(func() {
-		err := service.Response(suggestions, config.OutputSARIF, "")
+		err := service.Response(Report{Suggestions: suggestions, Format: config.OutputSARIF})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -129,7 +129,7 @@ func TestResponse_WritesSARIFToFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "zanadir.sarif")
 
 	out := captureStdout(func() {
-		if err := service.Response(suggestions, config.OutputSARIF, path); err != nil {
+		if err := service.Response(Report{Suggestions: suggestions, Format: config.OutputSARIF, DestPath: path}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -155,7 +155,7 @@ func TestResponse_WritesTableToFile(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "report.txt")
 
-	if err := service.Response(getSampleSuggestions(), config.OutputTable, path); err != nil {
+	if err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputTable, DestPath: path}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -173,7 +173,7 @@ func TestResponse_ReportsUnwritableDestination(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "no-such-dir", "zanadir.sarif")
 
-	err := service.Response(getSampleSuggestions(), config.OutputSARIF, path)
+	err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputSARIF, DestPath: path})
 	if err == nil {
 		t.Fatal("expected an error for an unwritable destination")
 	}
@@ -188,7 +188,7 @@ func TestResponse_TableStatesWhenNothingToSuggest(t *testing.T) {
 	service := NewOutputService()
 
 	out := captureStdout(func() {
-		if err := service.Response(nil, config.OutputTable, ""); err != nil {
+		if err := service.Response(Report{Suggestions: nil, Format: config.OutputTable}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -205,7 +205,7 @@ func TestResponse_TableLeadsWithACount(t *testing.T) {
 	service := NewOutputService()
 
 	out := captureStdout(func() {
-		if err := service.Response(getSampleSuggestions(), config.OutputTable, ""); err != nil {
+		if err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputTable}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -235,7 +235,7 @@ func TestResponse_NoColourWhenNotATerminal(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "report.txt")
 
-	if err := service.Response(getSampleSuggestions(), config.OutputTable, path); err != nil {
+	if err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputTable, DestPath: path}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -247,7 +247,7 @@ func TestResponse_NoColourWhenNotATerminal(t *testing.T) {
 	}
 
 	out := captureStdout(func() {
-		_ = service.Response(getSampleSuggestions(), config.OutputTable, "")
+		_ = service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputTable})
 	})
 	if strings.Contains(out, "\x1b[") {
 		t.Errorf("piped stdout contains ANSI escapes:\n%q", out)
@@ -260,7 +260,7 @@ func TestResponse_MachineFormatsHaveNoHeadline(t *testing.T) {
 
 	for _, format := range []string{"json", config.OutputSARIF} {
 		out := captureStdout(func() {
-			if err := service.Response(getSampleSuggestions(), format, ""); err != nil {
+			if err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: format}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
@@ -323,7 +323,7 @@ func TestRenderPropagatesWriteErrors(t *testing.T) {
 
 	for _, format := range []string{config.OutputTable, config.OutputSARIF, "json"} {
 		t.Run(format, func(t *testing.T) {
-			err := render(w, getSampleSuggestions(), format)
+			err := render(w, Report{Suggestions: getSampleSuggestions(), Format: format})
 			if !errors.Is(err, boom) {
 				t.Errorf("expected the write error to propagate, got %v", err)
 			}
@@ -334,7 +334,7 @@ func TestRenderPropagatesWriteErrors(t *testing.T) {
 func TestRenderPropagatesWriteErrorOnAllClear(t *testing.T) {
 	boom := errors.New("disk full")
 
-	if err := render(failingWriter{err: boom}, nil, config.OutputTable); !errors.Is(err, boom) {
+	if err := render(failingWriter{err: boom}, Report{Format: config.OutputTable}); !errors.Is(err, boom) {
 		t.Errorf("expected the write error to propagate, got %v", err)
 	}
 }
@@ -346,7 +346,7 @@ func TestResponse_ReportIsReadableByOthers(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "zanadir.sarif")
 
-	if err := service.Response(getSampleSuggestions(), config.OutputSARIF, path); err != nil {
+	if err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputSARIF, DestPath: path}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -121,8 +121,6 @@ func TestWrapTextEmptyInput(t *testing.T) {
 	}
 }
 
-// Writing to a file is what lets CI hand a SARIF report to a consumer such as
-// GitHub code scanning, so the report must land in the file and not on stdout.
 func TestResponse_WritesSARIFToFile(t *testing.T) {
 	service := NewOutputService()
 	suggestions := getSampleSuggestions()
@@ -168,7 +166,6 @@ func TestResponse_WritesTableToFile(t *testing.T) {
 	}
 }
 
-// A report the operator asked for but never got is worse than no report.
 func TestResponse_ReportsUnwritableDestination(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "no-such-dir", "zanadir.sarif")
@@ -182,8 +179,6 @@ func TestResponse_ReportsUnwritableDestination(t *testing.T) {
 	}
 }
 
-// A clean repository used to render an empty table: three border lines and a
-// header row with no body, which reads as a bug rather than a pass.
 func TestResponse_TableStatesWhenNothingToSuggest(t *testing.T) {
 	service := NewOutputService()
 
@@ -230,7 +225,6 @@ func TestHeadlineIsGrammatical(t *testing.T) {
 	}
 }
 
-// Escape codes in a redirected report would corrupt it for any consumer.
 func TestResponse_NoColourWhenNotATerminal(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "report.txt")
@@ -254,7 +248,6 @@ func TestResponse_NoColourWhenNotATerminal(t *testing.T) {
 	}
 }
 
-// The machine formats must not gain a human headline.
 func TestResponse_MachineFormatsHaveNoHeadline(t *testing.T) {
 	service := NewOutputService()
 
@@ -273,8 +266,6 @@ func TestResponse_MachineFormatsHaveNoHeadline(t *testing.T) {
 	}
 }
 
-// failingWriter reports an error on every write, standing in for a full disk or
-// a closed pipe.
 type failingWriter struct{ err error }
 
 func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
@@ -315,8 +306,6 @@ func TestPaint(t *testing.T) {
 	}
 }
 
-// A report that cannot be written must surface the failure rather than
-// reporting success on output nobody received.
 func TestRenderPropagatesWriteErrors(t *testing.T) {
 	boom := errors.New("disk full")
 	w := failingWriter{err: boom}
@@ -339,9 +328,6 @@ func TestRenderPropagatesWriteErrorOnAllClear(t *testing.T) {
 	}
 }
 
-// A report is written to be consumed by another process, often another user:
-// the Docker action runs as root while the following step runs as the runner
-// user. An owner-only report is unreadable there, which broke SARIF upload.
 func TestResponse_ReportIsReadableByOthers(t *testing.T) {
 	service := NewOutputService()
 	path := filepath.Join(t.TempDir(), "zanadir.sarif")

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -98,11 +98,7 @@ func helpText(suggestion *suggester.CategorySuggestion) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// buildSarif converts category suggestions into a SARIF log: one rule and one
-// result per uncovered category. Each result is anchored at anchor, a
-// repository-relative CI configuration file: a missing control is not a defect
-// on a particular line, but every SARIF consumer expects a location, and the
-// file where the tool would be added is the most useful one available.
+// buildSarif converts suggestions into one rule and one result per category.
 func buildSarif(suggestions []*suggester.CategorySuggestion, anchor string) sarifLog {
 	rules := make([]sarifRule, 0, len(suggestions))
 	results := make([]sarifResult, 0, len(suggestions))
@@ -129,17 +125,13 @@ func buildSarif(suggestions []*suggester.CategorySuggestion, anchor string) sari
 		}
 
 		result := sarifResult{
-			RuleID:  suggestion.ID,
-			Level:   "warning",
-			Message: sarifMessage{Text: message},
-			// The category is the finding's whole identity.
+			RuleID:              suggestion.ID,
+			Level:               "warning",
+			Message:             sarifMessage{Text: message},
 			PartialFingerprints: map[string]string{"categoryId": suggestion.ID},
 		}
 
-		// GitHub code scanning rejects a result with no location outright:
-		// "locationFromSarifResult: expected at least one location". Anchor
-		// each one at a CI configuration file - the place the missing tool
-		// would be added - which is also more useful than no location at all.
+		// Code scanning rejects a result with no location.
 		if anchor != "" {
 			result.Locations = []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -63,7 +63,25 @@ type sarifResult struct {
 	RuleID              string            `json:"ruleId"`
 	Level               string            `json:"level"`
 	Message             sarifMessage      `json:"message"`
+	Locations           []sarifLocation   `json:"locations,omitempty"`
 	PartialFingerprints map[string]string `json:"partialFingerprints"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           sarifRegion           `json:"region"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
 }
 
 // helpText renders a category's suggested tools as a list.
@@ -81,9 +99,11 @@ func helpText(suggestion *suggester.CategorySuggestion) string {
 }
 
 // buildSarif converts category suggestions into a SARIF log: one rule and one
-// result per uncovered category. Results carry no physical location, since a
-// missing control is the absence of configuration rather than a defect in a file.
-func buildSarif(suggestions []*suggester.CategorySuggestion) sarifLog {
+// result per uncovered category. Each result is anchored at anchor, a
+// repository-relative CI configuration file: a missing control is not a defect
+// on a particular line, but every SARIF consumer expects a location, and the
+// file where the tool would be added is the most useful one available.
+func buildSarif(suggestions []*suggester.CategorySuggestion, anchor string) sarifLog {
 	rules := make([]sarifRule, 0, len(suggestions))
 	results := make([]sarifResult, 0, len(suggestions))
 
@@ -108,13 +128,28 @@ func buildSarif(suggestions []*suggester.CategorySuggestion) sarifLog {
 			message = fmt.Sprintf("%s Consider adding one of: %s.", message, strings.Join(toolNames, ", "))
 		}
 
-		results = append(results, sarifResult{
+		result := sarifResult{
 			RuleID:  suggestion.ID,
 			Level:   "warning",
 			Message: sarifMessage{Text: message},
 			// The category is the finding's whole identity.
 			PartialFingerprints: map[string]string{"categoryId": suggestion.ID},
-		})
+		}
+
+		// GitHub code scanning rejects a result with no location outright:
+		// "locationFromSarifResult: expected at least one location". Anchor
+		// each one at a CI configuration file - the place the missing tool
+		// would be added - which is also more useful than no location at all.
+		if anchor != "" {
+			result.Locations = []sarifLocation{{
+				PhysicalLocation: sarifPhysicalLocation{
+					ArtifactLocation: sarifArtifactLocation{URI: anchor},
+					Region:           sarifRegion{StartLine: 1},
+				},
+			}}
+		}
+
+		results = append(results, result)
 	}
 
 	return sarifLog{
@@ -131,8 +166,8 @@ func buildSarif(suggestions []*suggester.CategorySuggestion) sarifLog {
 	}
 }
 
-func renderSarif(suggestions []*suggester.CategorySuggestion) (string, error) {
-	data, err := json.MarshalIndent(buildSarif(suggestions), "", "  ")
+func renderSarif(suggestions []*suggester.CategorySuggestion, anchor string) (string, error) {
+	data, err := json.MarshalIndent(buildSarif(suggestions, anchor), "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal SARIF report: %w", err)
 	}

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -29,7 +29,7 @@ func testSuggestions() []*suggester.CategorySuggestion {
 }
 
 func TestBuildSarifStructure(t *testing.T) {
-	log := buildSarif(testSuggestions())
+	log := buildSarif(testSuggestions(), "")
 
 	assert.Equal(t, sarifVersion, log.Version)
 	assert.Equal(t, sarifSchema, log.Schema)
@@ -54,7 +54,7 @@ func TestBuildSarifStructure(t *testing.T) {
 }
 
 func TestSarifHelpListsTools(t *testing.T) {
-	log := buildSarif(testSuggestions())
+	log := buildSarif(testSuggestions(), "")
 
 	var scaHelp, coverageHelp string
 	for _, rule := range log.Runs[0].Tool.Driver.Rules {
@@ -76,7 +76,7 @@ func TestSarifHelpListsTools(t *testing.T) {
 }
 
 func TestSarifMessageMentionsTools(t *testing.T) {
-	log := buildSarif(testSuggestions())
+	log := buildSarif(testSuggestions(), "")
 
 	for _, result := range log.Runs[0].Results {
 		if result.RuleID == "SCA" {
@@ -86,7 +86,7 @@ func TestSarifMessageMentionsTools(t *testing.T) {
 }
 
 func TestRenderSarifIsValidJSON(t *testing.T) {
-	report, err := renderSarif(testSuggestions())
+	report, err := renderSarif(testSuggestions(), "")
 	assert.NoError(t, err)
 
 	var decoded map[string]interface{}
@@ -97,11 +97,56 @@ func TestRenderSarifIsValidJSON(t *testing.T) {
 
 // SARIF requires runs[].results, so it must serialise as [] rather than null.
 func TestRenderSarifWithNoSuggestions(t *testing.T) {
-	report, err := renderSarif(nil)
+	report, err := renderSarif(nil, "")
 	assert.NoError(t, err)
 	assert.Contains(t, report, `"results": []`)
 	assert.Contains(t, report, `"rules": []`)
 
 	var decoded map[string]interface{}
 	assert.NoError(t, json.Unmarshal([]byte(report), &decoded))
+}
+
+// GitHub code scanning rejects the whole upload when any result has no
+// location: "locationFromSarifResult: expected at least one location".
+func TestSarifResultsCarryALocation(t *testing.T) {
+	log := buildSarif(testSuggestions(), ".github/workflows/ci.yml")
+
+	assert.NotEmpty(t, log.Runs[0].Results)
+	for _, result := range log.Runs[0].Results {
+		assert.Len(t, result.Locations, 1, "result %q must carry a location", result.RuleID)
+		phys := result.Locations[0].PhysicalLocation
+		assert.Equal(t, ".github/workflows/ci.yml", phys.ArtifactLocation.URI)
+		assert.Equal(t, 1, phys.Region.StartLine)
+	}
+}
+
+func TestSarifOmitsLocationWithoutAnAnchor(t *testing.T) {
+	log := buildSarif(testSuggestions(), "")
+
+	for _, result := range log.Runs[0].Results {
+		assert.Empty(t, result.Locations, "no anchor means no location rather than a wrong one")
+	}
+}
+
+func TestRenderSarifSerialisesLocations(t *testing.T) {
+	report, err := renderSarif(testSuggestions(), ".github/workflows/ci.yml")
+	assert.NoError(t, err)
+
+	var decoded struct {
+		Runs []struct {
+			Results []struct {
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(report), &decoded))
+	assert.Len(t, decoded.Runs[0].Results[0].Locations, 1)
+	assert.Equal(t, ".github/workflows/ci.yml",
+		decoded.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
 }

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -106,8 +106,6 @@ func TestRenderSarifWithNoSuggestions(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(report), &decoded))
 }
 
-// GitHub code scanning rejects the whole upload when any result has no
-// location: "locationFromSarifResult: expected at least one location".
 func TestSarifResultsCarryALocation(t *testing.T) {
 	log := buildSarif(testSuggestions(), ".github/workflows/ci.yml")
 

--- a/rules/regex_test.go
+++ b/rules/regex_test.go
@@ -162,8 +162,7 @@ func TestRuleRegexPrecision(t *testing.T) {
 			shouldNotMatch: []string{"mycodecovx"},
 		},
 		{
-			// Shell text is free-form: a bare \btests?\b would count
-			// `if test -f`, `test -z` and test.example.com as coverage.
+			// A bare \btests?\b would count `if test -f` as coverage.
 			ruleID: "unit-test-command-rule",
 			shouldMatch: []string{
 				"go test ./...", "go test -race -cover ./...", "npm test", "npm run test",

--- a/suggester/suggester_test.go
+++ b/suggester/suggester_test.go
@@ -164,10 +164,6 @@ func TestFindSuggestionsDoesNotMutateSharedCatalogue(t *testing.T) {
 	assert.Contains(t, toolNames(findCategory(unfiltered, "Linter")), "ESLint")
 }
 
-// The catalogue is the entire user-facing text of a scan, and a copy-pasted
-// description silently misdescribes a category on every run — Performance
-// Testing shipped with Code Coverage's wording. Assert the text is distinct
-// and complete so the next paste is caught here rather than by a user.
 func TestCatalogueDescriptionsAreDistinctAndComplete(t *testing.T) {
 	s, err := suggester.NewSuggestionService()
 	assert.NoError(t, err)


### PR DESCRIPTION
## The bug

GitHub code scanning rejects the **entire upload** when any result has no location:

```
##[error]Code Scanning could not process the submitted SARIF file:
locationFromSarifResult: expected at least one location
```

zanadir emitted results with no location deliberately — #133 reasoned that "a missing control is the absence of configuration rather than a defect on a particular line". Sound reasoning, but it made the report unusable by the one consumer the feature exists to serve. Found by dogfooding in #145.

## The fix

Anchor each result at a repository-relative CI configuration path — the file where the missing tool would be added:

```json
"locations": [{
  "physicalLocation": {
    "artifactLocation": { "uri": ".github/workflows/ci.yml" },
    "region": { "startLine": 1 }
  }
}]
```

The path comes from the scanned artifacts and is skipped when it cannot be made relative to the scan directory — a wrong location is worse than none.

## Also in this PR

**`Response` takes a struct.** The interface had grown to three positional arguments, two of them interchangeable strings, and this would have added a fourth. `output.Report{Suggestions, Format, DestPath, Anchor}` replaces them.

**Comments cut back** (second commit). Recent changes had pushed comment density to 7–13% of lines against 0–4% in the surrounding code — 50 comment lines removed, 12 added. Kept the notes explaining non-obvious choices (the `0644` mode, why nothing inside the table is styled, why a location is required); dropped restatement and history that belongs in commit messages. This also removes a duplicated doc comment left stranded above the ANSI block by an earlier edit.

## Verification

Real scan of this repository:

```
results: 2
results WITHOUT a location: none
  Performance Testing    -> .github/workflows/CRobot.yml:1
  IaC Security           -> .github/workflows/CRobot.yml:1
```

Tests cover results carrying a location, the no-anchor fallback, JSON serialisation, and `sarifAnchor` across relative paths, missing locations, paths outside the scan directory, and no artifacts.

## Known rough edge

The anchor is the **first** artifact found, effectively arbitrary when a repo has several workflows. All alerts for a scan point at the same file. Choosing a more representative one is a follow-up; it does not affect validity.

Needs a `0.2.2` release and action `v1.8` before #145 can pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)