### PR TITLE
fix: bring the Homebrew formula up to date

### DIFF
--- a/Formula/zanadir.rb
+++ b/Formula/zanadir.rb
@@ -1,26 +1,10 @@
 class Zanadir < Formula
-  desc "A tool for directory navigation and management"
+  desc "Scans CI/CD pipelines and suggests missing security and quality tools"
   homepage "https://github.com/MustacheCase/zanadir"
+  url "https://github.com/MustacheCase/zanadir/archive/refs/tags/0.2.2.tar.gz"
+  sha256 "b1b7290fb98b322a1a9db5c0e21f13ae3d697751339fe32ce1f76688410ece16"
   license "MIT"
-
-  # Get the latest version from git tags
-  version = "0.1.1"
-  
-  stable do
-    url "https://github.com/MustacheCase/zanadir/archive/#{version}.tar.gz"
-    sha256 "84165bcdc12ff56058ff438fe7cbbdd3d694c24bb9f4d2f546184ce83ca0adbc"
-    version version
-  end
-
   head "https://github.com/MustacheCase/zanadir.git", branch: "main"
-
-  # Note: If the project requires specific Go dependencies at build time,
-  # use go_resource blocks to specify them. Example:
-  # go_resource "github.com/some/dependency" do
-  #   url "https://github.com/some/dependency.git",
-  #       :tag => "v1.0.0"
-  # end
-  # This ensures consistent builds across different environments.
 
   depends_on "go" => :build
 
@@ -28,10 +12,22 @@ class Zanadir < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
-  # Test verifies that the binary was built correctly and can execute basic commands
-  # by checking if the help command works, which indicates the CLI is properly
-  # initialized and can process commands.
   test do
-    system "#{bin}/zanadir", "--help"
+    assert_match "zanadir", shell_output("#{bin}/zanadir --help")
+
+    (testpath/".github/workflows").mkpath
+    (testpath/".github/workflows/ci.yml").write <<~YAML
+      name: ci
+      on: [push]
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - run: go test ./...
+    YAML
+    system "git", "init"
+
+    output = shell_output("#{bin}/zanadir scan --dir #{testpath} --output json")
+    assert_match "\"ID\"", output
   end
-end 
+end

--- a/README.md
+++ b/README.md
@@ -289,8 +289,10 @@ Or using Homebrew:
 ```sh
 # Install using Homebrew (custom tap)
 brew tap --custom-remote MustacheCase/zanadir https://github.com/MustacheCase/zanadir.git
-brew install zanadir
+brew install mustachecase/zanadir/zanadir
 ```
+
+The tap is this repository, so the formula lives in `Formula/zanadir.rb`.
 
 ## GitHub Actions
 If you're using GitHub Actions, you can use our [Zanadir-based action](https://github.com/MustacheCase/zanadir-action) to run CI\CD scans on your code during your CI workflows.

--- a/scripts/update-brew-version.sh
+++ b/scripts/update-brew-version.sh
@@ -1,37 +1,34 @@
 #!/bin/bash
+# Point the Homebrew formula at the latest released tag.
+# Usage: ./scripts/update-brew-version.sh [tag]
 
-# Script to update Homebrew formula with latest version
-# Usage: ./scripts/update-brew-version.sh
+set -euo pipefail
 
-set -e
-
-# Get the latest version tag (handle both v0.0.5 and 0.1.1 formats)
-LATEST_VERSION=$(git tag -l | sort -V | tail -1)
-echo "Latest version: $LATEST_VERSION"
-
-# Remove 'v' prefix if present
-VERSION_NUMBER=${LATEST_VERSION#v}
-
-# Download the tarball and calculate SHA256
-TARBALL_URL="https://github.com/MustacheCase/zanadir/archive/${LATEST_VERSION}.tar.gz"
-echo "Downloading: $TARBALL_URL"
-
-# Download and calculate SHA256
-SHA256=$(curl -sL "$TARBALL_URL" | shasum -a 256 | cut -d' ' -f1)
-echo "SHA256: $SHA256"
-
-# Update the formula file
 FORMULA_FILE="Formula/zanadir.rb"
+TAG="${1:-$(git tag -l | sort -V | tail -1)}"
 
-# Create backup
-cp "$FORMULA_FILE" "$FORMULA_FILE.backup"
+if [ -z "$TAG" ]; then
+  echo "No tag found; pass one explicitly." >&2
+  exit 1
+fi
 
-# Update version and SHA256 in the formula
-sed -i.bak "s/version = \"[^\"]*\"/version = \"$VERSION_NUMBER\"/" "$FORMULA_FILE"
-sed -i.bak "s/sha256 \"[^\"]*\"/sha256 \"$SHA256\"/" "$FORMULA_FILE"
+URL="https://github.com/MustacheCase/zanadir/archive/refs/tags/${TAG}.tar.gz"
+echo "Tag:  $TAG"
+echo "URL:  $URL"
 
-# Clean up backup files
-rm -f "$FORMULA_FILE.backup" "$FORMULA_FILE.bak"
+SHA256=$(curl -fsSL "$URL" | shasum -a 256 | cut -d' ' -f1)
+if [ -z "$SHA256" ]; then
+  echo "Could not download $URL" >&2
+  exit 1
+fi
+echo "SHA:  $SHA256"
 
-echo "Updated $FORMULA_FILE with version $VERSION_NUMBER and SHA256 $SHA256"
-echo "Don't forget to commit and push these changes!"
+sed -i.bak -E "s|^  url \".*\"|  url \"${URL}\"|" "$FORMULA_FILE"
+sed -i.bak -E "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" "$FORMULA_FILE"
+rm -f "$FORMULA_FILE.bak"
+
+echo
+echo "Updated $FORMULA_FILE:"
+grep -E '^  (url|sha256) ' "$FORMULA_FILE"
+echo
+echo "The tap is this repository, so committing to main publishes the formula."


### PR DESCRIPTION
Closes #121.

## What was actually wrong

I reproduced it first. `brew install` **does not error** — it builds and installs fine. The problems are different:

1. **It installs 0.1.1**, three releases behind. Anyone installing via brew today gets an August 2025 build with no SAST, no IaC Security, no `--fail-on`, no SARIF.
2. **The description is for a different tool entirely**: *"A tool for directory navigation and management"* — that is what `brew info` and `brew search` show.
3. `update-brew-version.sh` rewrote a `version = "..."` assignment, so running it produced a formula whose `stable do` block still pointed at the old tarball.

My earlier theory that the Go 1.26 toolchain broke the build was **wrong** — brew installs Go 1.27 as a build dependency and the build succeeds.

Also worth recording: the tap is **this repository** (`brew tap --custom-remote`), so `Formula/zanadir.rb` here is the file brew reads. The separate `homebrew-zanadir` repo is not involved.

## Changes

- Formula points at **0.2.2** with the correct sha256
- Description fixed
- Replaced the `version = "..."` + `stable do` pattern with the standard `url`/`sha256` pair
- `test do` now writes a fixture workflow and asserts the JSON report, instead of only running `--help`
- `update-brew-version.sh` rewritten to update `url` and `sha256`, and to accept an explicit tag
- README uses the fully-qualified `brew install mustachecase/zanadir/zanadir`

## Verified on a real install

```console
$ brew install mustachecase/zanadir/zanadir
🍺  /opt/homebrew/Cellar/zanadir/0.2.2: 6 files, 5.4MB, built in 1 second

$ brew list --versions zanadir
zanadir 0.2.2

$ zanadir scan --help | grep -E 'output-file|fail-on|baseline'
      --baseline string     Path to a baseline file of already-accepted gaps
      --fail-on strings     Fail only when these specific categories are uncovered
      --output-file string  Write the report to this file instead of stdout

$ zanadir scan --dir . --output json
categories: [SCA, Secrets Detection, License Compliance, End Of Life, Coverage,
             Linter, Performance Testing, Unit Tests, SAST, IaC Security]

$ brew test zanadir
exit 0
```

The formula was staged into the tap clone to install it before merging; that clone has been restored to a clean git state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)