### PR TITLE
chore: allow CodeQL to be run by hand

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,11 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '36 2 * * 4'
+  # Lets the analysis be started by hand. A scheduled-only workflow is
+  # disabled automatically after a quiet period, and this one was: it last
+  # ran in February and no push or pull request restarted it, because a
+  # disabled workflow ignores every trigger.
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
Fixes the **"Code scanning configuration error"**.

## Cause

The CodeQL workflow was in state `disabled_inactivity`:

```
name=CodeQL Advanced  state=disabled_inactivity  path=.github/workflows/codeql.yml
```

GitHub disables a scheduled workflow automatically after a quiet period, and this repository was dormant between the February and August releases. Its **last successful run was 2026-02-12**.

The part that makes it easy to miss: a disabled workflow ignores **every** trigger, not just the schedule. `codeql.yml` also runs on push to `main` and on pull requests, but none of this month's pushes restarted it. So CodeQL silently produced nothing for six months while code scanning kept expecting results from it — which is what the configuration error reports.

Default setup is `not-configured`, so the advanced workflow is the only CodeQL analysis; nothing was covering for it.

## What I did

- **Re-enabled the workflow** (already done, outside this PR — it is repository state, not a file)
- This PR adds `workflow_dispatch`, so the analysis can be started by hand rather than waiting for the Thursday cron, and can be confirmed working after a lapse like this one

This PR targets `main`, so CodeQL runs on it — which is the check that it is genuinely fixed.

## Also disabled, left alone deliberately

`.github/workflows/DependencyUpdate.yml` is also `disabled_inactivity`. I have **not** re-enabled it: it runs daily and opens a new pull request each time, with the run ID in the branch name, so they accumulate rather than update in place. Worth deciding on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)