### PR TITLE
chore: point the Homebrew formula at 0.3.0

### DIFF
--- a/Formula/zanadir.rb
+++ b/Formula/zanadir.rb
@@ -1,8 +1,8 @@
 class Zanadir < Formula
   desc "Scans CI/CD pipelines and suggests missing security and quality tools"
   homepage "https://github.com/MustacheCase/zanadir"
-  url "https://github.com/MustacheCase/zanadir/archive/refs/tags/0.2.2.tar.gz"
-  sha256 "b1b7290fb98b322a1a9db5c0e21f13ae3d697751339fe32ce1f76688410ece16"
+  url "https://github.com/MustacheCase/zanadir/archive/refs/tags/0.3.0.tar.gz"
+  sha256 "1cf80d01ffdbc2951d6a3f022635e3c4448232396304f015451d5fd12af47196"
   license "MIT"
   head "https://github.com/MustacheCase/zanadir.git", branch: "main"
 


### PR DESCRIPTION
Produced by `./scripts/update-brew-version.sh 0.3.0` — the first run of that script since #148 fixed it.

`brew install mustachecase/zanadir/zanadir` will install 0.3.0 with `zanadir fix` once this is on `main`, since the tap is this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)