### PR TITLE
feat: add a Supply Chain category

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ case-insensitive):
 - 🧪 **Unit Tests**: Automated Unit Testing
 - 🔎 **SAST**: Static Application Security Testing
 - 🏗️ **IaC Security**: Infrastructure-as-Code Misconfiguration Scanning
+- 🔗 **Supply Chain**: SBOM Generation, Signing and Provenance
 
 ## Usage Examples
 

--- a/fixer/templates.yaml
+++ b/fixer/templates.yaml
@@ -155,3 +155,16 @@ templates:
         uses: grafana/k6-action@v0.3.1
         with:
           filename: load-test.js
+
+  # Cosign and the attestation actions need id-token and attestations
+  # permissions, which the generated standalone workflow does not grant, so
+  # only SBOM generation is templated for this category.
+  - tool: "Syft"
+    platform: "github"
+    step: |
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          artifact-name: sbom.spdx.json
+

--- a/models/categories.go
+++ b/models/categories.go
@@ -13,11 +13,12 @@ const (
 	UnitTests          CategoryTitle = "Unit Tests"
 	SAST               CategoryTitle = "SAST"
 	IaC                CategoryTitle = "IaC Security"
+	SupplyChain        CategoryTitle = "Supply Chain"
 	Table              Format        = "table"
 	JSON               Format        = "json"
 )
 
-var CategoryTitles = []CategoryTitle{SCA, Secrets, Licenses, EndOfLife, Coverage, Linter, PerformanceTesting, UnitTests, SAST, IaC}
+var CategoryTitles = []CategoryTitle{SCA, Secrets, Licenses, EndOfLife, Coverage, Linter, PerformanceTesting, UnitTests, SAST, IaC, SupplyChain}
 
 type CategoryTitle string
 

--- a/rules/regex_test.go
+++ b/rules/regex_test.go
@@ -177,6 +177,43 @@ func TestRuleRegexPrecision(t *testing.T) {
 				"latest", "deploy-latest",
 			},
 		},
+		{
+			ruleID:         "syft-rule",
+			shouldMatch:    []string{"syft dir:. -o spdx-json", "anchore/sbom-action@v0"},
+			shouldNotMatch: []string{"syftly", "mysyft"},
+		},
+		{
+			ruleID:         "cosign-rule",
+			shouldMatch:    []string{"cosign sign --yes $IMAGE", "sigstore/cosign-installer@v3"},
+			shouldNotMatch: []string{"cosigning the release", "cosigner"},
+		},
+		{
+			// A bare "spdx" matches the licence header, which says nothing
+			// about whether an SBOM is produced.
+			ruleID:      "spdx-tools-rule",
+			shouldMatch: []string{"spdx-sbom-generator -p .", "spdx-tools convert"},
+			shouldNotMatch: []string{
+				"# SPDX-License-Identifier: MIT",
+				"SPDX-License-Identifier: Apache-2.0",
+				"spdx",
+			},
+		},
+		{
+			ruleID:         "slsa-rule",
+			shouldMatch:    []string{"slsa-framework/slsa-github-generator", "slsa provenance"},
+			shouldNotMatch: []string{"slsawesome", "salsa", "slsax"},
+		},
+		{
+			ruleID:         "github-attestation-rule",
+			shouldMatch:    []string{"actions/attest-build-provenance@v1", "actions/attest-sbom@v1"},
+			shouldNotMatch: []string{"actions/checkout@v4", "attestation"},
+		},
+		{
+			// "trivy" alone is SCA; the sbom sub-command is supply chain.
+			ruleID:         "trivy-sbom-rule",
+			shouldMatch:    []string{"trivy sbom --format cyclonedx .", "trivy  sbom ."},
+			shouldNotMatch: []string{"trivy fs .", "trivy image alpine", "trivy config ."},
+		},
 	}
 
 	for _, tt := range tests {

--- a/rules/storage/supply-chain.yaml
+++ b/rules/storage/supply-chain.yaml
@@ -1,0 +1,43 @@
+rules:
+  - id: "syft-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)\\bsyft\\b|anchore/sbom-action"
+
+  - id: "cyclonedx-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)\\bcyclonedx\\b|\\bcdxgen\\b"
+
+  # A bare "spdx" matches the SPDX-License-Identifier header, which appears in
+  # workflows that generate no SBOM at all.
+  - id: "spdx-tools-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)spdx-sbom-generator|\\bspdx-tools\\b"
+
+  - id: "cosign-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)\\bcosign\\b|sigstore/cosign-installer"
+
+  - id: "slsa-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)slsa-framework/|\\bslsa\\b"
+
+  - id: "in-toto-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)\\bin-toto\\b"
+
+  - id: "github-attestation-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)actions/attest-(build-provenance|sbom)"
+
+  # "trivy" alone is SCA; the sbom sub-command generates a bill of materials.
+  - id: "trivy-sbom-rule"
+    applyOn: ["Artifact.Name", "Job.Package", "Job.Run"]
+    categories: ["Supply Chain"]
+    regex: "(?i)\\btrivy\\s+sbom\\b"

--- a/suggester/suggestions.yaml
+++ b/suggester/suggestions.yaml
@@ -209,3 +209,23 @@ categories:
         repository: "https://github.com/kubescape/kubescape"
         description: "Scans Kubernetes manifests and clusters against security frameworks such as NSA and MITRE."
 
+  - id: "Supply Chain"
+    name: "Supply Chain Security and SBOM"
+    description: "Tools that record what a build contains and prove where it came from, so a compromised dependency or artifact can be traced rather than guessed at."
+    suggestions:
+      - name: "Syft"
+        repository: "https://github.com/anchore/syft"
+        description: "Generates an SBOM from container images and filesystems, in SPDX or CycloneDX format."
+      - name: "CycloneDX"
+        repository: "https://github.com/CycloneDX/cdxgen"
+        description: "Generates CycloneDX bills of materials across many language ecosystems."
+      - name: "Cosign"
+        repository: "https://github.com/sigstore/cosign"
+        description: "Signs and verifies container images and artifacts, keylessly via Sigstore."
+      - name: "SLSA GitHub Generator"
+        repository: "https://github.com/slsa-framework/slsa-github-generator"
+        description: "Produces SLSA provenance for a build, attesting how an artifact was produced."
+      - name: "GitHub Artifact Attestations"
+        repository: "https://github.com/actions/attest-build-provenance"
+        description: "Creates signed build provenance for artifacts directly from a workflow."
+


### PR DESCRIPTION
The eleventh category, and the third pillar after SAST and IaC Security.

## Why

Nothing looked for a bill of materials, a signature, or build provenance — so a repository could not say what its artifacts contain or where they came from. This is the fastest-growing area of CI/CD security and the most conspicuous remaining gap.

## Changes

- New `Supply Chain` category
- **8 rules**: Syft, CycloneDX/cdxgen, SPDX tools, Cosign, SLSA, in-toto, GitHub artifact attestations, `trivy sbom`
- **5 suggestions**: Syft, CycloneDX, Cosign, SLSA GitHub Generator, GitHub Artifact Attestations
- A `fix` template for SBOM generation, so the category is actionable rather than only reported

## The regex that would have been wrong

The obvious rule for SPDX is `\bspdx\b`. It is wrong, and I checked before writing it:

```
FALSE POSITIVE  spdx-BAD  ['# SPDX-License-Identifier: MIT',
                           'SPDX-License-Identifier: Apache-2.0']
```

That header appears in workflows that generate no SBOM whatsoever, so the rule would have reported the category **covered** for them — the failure mode #132 and the Bearer rule in #140 were both about. The rule matches `spdx-sbom-generator` and `spdx-tools` instead, with the licence header as an explicit `shouldNotMatch` case.

As with the other shared tools, `trivy` stays with SCA and only `trivy sbom` counts here.

## Verified end to end

- A workflow with an `SPDX-License-Identifier` header and `trivy fs .` → Supply Chain **uncovered**
- The same workflow using `anchore/sbom-action@v0` → **covered**

## Deliberately not templated

Cosign and the attestation actions are detected but have no `fix` template: they need `id-token` and `attestations` permissions that the generated standalone workflow does not grant. Emitting a step that always fails would be worse than emitting nothing.

## Note for existing users

An eleventh category means one more suggestion for repositories without SBOM tooling, and a new failure for anyone running `--enforce` without `--fail-on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)