### PR TITLE
feat: score category coverage and write a README badge

### DIFF
--- a/.github/workflows/ZanadirScan.yml
+++ b/.github/workflows/ZanadirScan.yml
@@ -32,3 +32,35 @@ jobs:
       with:
         sarif_file: zanadir.sarif
         category: zanadir
+
+  # Builds from source rather than using the action: the published action
+  # predates --badge. Only pushes to main publish, so a fork's pull request
+  # cannot move the badge.
+  badge:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Score our own coverage
+      run: go run . scan --dir . --badge .github/zanadir-badge.json
+
+    - name: Commit the badge when it moved
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .github/zanadir-badge.json
+        if git diff --staged --quiet; then
+          echo "Coverage unchanged."
+          exit 0
+        fi
+        git commit -m "chore: update the zanadir coverage badge"
+        git push

--- a/.github/zanadir-badge.json
+++ b/.github/zanadir-badge.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "zanadir",
+  "message": "8/11",
+  "color": "yellow"
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ zanadir scan --dir . --output table
 
 **Sample Output:**
 ```
-1 category needs attention:
+Coverage 10/11 - 1 category needs attention:
 
 |--------------------------------|--------------------------------|-------------------|
 |            CATEGORY            |          DESCRIPTION           |  SUGGESTED TOOLS  |
@@ -76,7 +76,7 @@ zanadir scan --dir . --output table
 When nothing is missing, the scan says so rather than printing an empty table:
 
 ```
-All categories are covered - no suggestions.
+Coverage 11/11 - all categories are covered.
 ```
 
 The headline is bold on an interactive terminal. Colour is omitted when the
@@ -155,6 +155,62 @@ To publish the report from a GitHub Actions workflow:
 
 Uncovered categories then appear in the repository's **Security** tab alongside
 your other scanners.
+
+## Coverage Score
+
+Every scan is summarised as a coverage score: the categories that apply to the
+repository, minus the ones still uncovered.
+
+Two rules keep the number honest:
+
+- **Excluded categories leave the denominator.** A repository is not marked
+  down for a category it has declared irrelevant with `--excluded-categories`.
+- **Baseline-accepted gaps still count as uncovered.** A baseline records that
+  a gap is tolerated, not that it was closed. A score that rose because someone
+  committed a file would measure nothing.
+
+### README Badge
+
+`--badge` writes the score as a [shields.io endpoint][shields] file:
+
+```sh
+zanadir scan --dir . --badge .github/zanadir-badge.json
+```
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "zanadir",
+  "message": "10/11",
+  "color": "green"
+}
+```
+
+Publish that file from CI and point a badge at it:
+
+```markdown
+![zanadir](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/.github/zanadir-badge.json)
+```
+
+A workflow that keeps it current on every push to the default branch:
+
+```yaml
+- name: Run zanadir
+  run: zanadir scan --dir . --badge .github/zanadir-badge.json
+
+- name: Commit the badge
+  run: |
+    git config user.name github-actions
+    git config user.email github-actions@github.com
+    git add .github/zanadir-badge.json
+    git diff --staged --quiet || git commit -m "chore: update zanadir badge"
+    git push
+```
+
+The colour tracks the score: green at 80% or above, yellow at 60%, orange at
+40%, red below that, and bright green only at full coverage.
+
+[shields]: https://shields.io/badges/endpoint-badge
 
 ## Language-Aware Suggestions
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="https://github.com/user-attachments/assets/88b976b4-cc46-4706-a3e4-3cfa0e6877d5" alt="zanadir">
 </p>
 
+<p align="center">
+  <a href="#coverage-score"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MustacheCase/zanadir/main/.github/zanadir-badge.json" alt="zanadir coverage"></a>
+</p>
+
 ## Features
 
 - 📂 **Scan**: Analyze the repository for CI/CD enhancement suggestions, including security services and best practices.
@@ -203,7 +207,8 @@ A workflow that keeps it current on every push to the default branch:
     git config user.name github-actions
     git config user.email github-actions@github.com
     git add .github/zanadir-badge.json
-    git diff --staged --quiet || git commit -m "chore: update zanadir badge"
+    if git diff --staged --quiet; then exit 0; fi
+    git commit -m "chore: update zanadir badge"
     git push
 ```
 

--- a/app/app.go
+++ b/app/app.go
@@ -75,6 +75,7 @@ func NewApp() *cobra.Command {
 	scanCmd.Flags().Bool("debug", false, "Run the tool using debug mode (optional)")
 	scanCmd.Flags().StringP("output", "o", "table", "Output format of the tool (table, json, sarif) (optional)")
 	scanCmd.Flags().String("output-file", "", "Write the report to this file instead of stdout (optional)")
+	scanCmd.Flags().String("badge", "", "Write a shields.io endpoint badge of the coverage score to this path (optional)")
 
 	_ = scanCmd.MarkFlagRequired("dir")
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	Output        string
 	// OutputFile writes the report to a path instead of stdout; empty means stdout.
 	OutputFile string
+	// Badge writes a shields.io endpoint badge to a path; empty means no badge.
+	Badge string
 	// Write makes the fix command generate a workflow instead of printing.
 	Write bool
 }
@@ -96,6 +98,7 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 	}
 
 	debug, _ := cmd.Flags().GetBool("debug")
+	badge, _ := cmd.Flags().GetString("badge")
 	outputFile, _ := cmd.Flags().GetString("output-file")
 	output, _ := cmd.Flags().GetString("output")
 	if output != OutputJSON && output != OutputTable && output != OutputSARIF {
@@ -112,6 +115,7 @@ func CreateConfig(cmd *cobra.Command) (*Config, error) {
 		Debug:              debug,
 		Output:             output,
 		OutputFile:         outputFile,
+		Badge:              badge,
 	}, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -101,6 +101,7 @@ func newScanCmd(dir string, excluded []string) *cobra.Command {
 	cmd.Flags().StringSlice("fail-on", nil, "fail on")
 	cmd.Flags().String("baseline", "", "baseline")
 	cmd.Flags().Bool("write-baseline", false, "write baseline")
+	cmd.Flags().String("badge", "", "badge")
 	return cmd
 }
 
@@ -223,4 +224,19 @@ func TestCreateFixConfigRequiresDir(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
+}
+
+func TestCreateConfigReadsTheBadgePath(t *testing.T) {
+	cmd := newScanCmd(t.TempDir(), nil)
+	assert.NoError(t, cmd.Flags().Set("badge", "badge.json"))
+
+	cfg, err := CreateConfig(cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, "badge.json", cfg.Badge)
+}
+
+func TestCreateConfigDefaultsToNoBadge(t *testing.T) {
+	cfg, err := CreateConfig(newScanCmd(t.TempDir(), nil))
+	assert.NoError(t, err)
+	assert.Empty(t, cfg.Badge)
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MustacheCase/zanadir/output"
 	"github.com/MustacheCase/zanadir/rules"
 	"github.com/MustacheCase/zanadir/scanner"
+	"github.com/MustacheCase/zanadir/score"
 	"github.com/MustacheCase/zanadir/suggester"
 )
 
@@ -134,15 +135,26 @@ func (h *Handler) Execute(cfg *config.Config) error {
 		return err
 	}
 
+	coverage := score.Of(cfg.ExcludedCategories, len(suggestions))
+	debugf("Coverage score: %s", coverage)
+
 	err = h.OutputService.Response(output.Report{
 		Suggestions: suggestions,
 		Format:      cfg.Output,
 		DestPath:    cfg.OutputFile,
 		Anchor:      sarifAnchor(cfg.Dir, artifacts),
+		Score:       coverage,
 	})
 	if err != nil {
 		debugf("Output error: %v", err)
 		return err
+	}
+
+	if cfg.Badge != "" {
+		if err := score.Write(cfg.Badge, coverage); err != nil {
+			return err
+		}
+		debugf("Wrote badge %s", cfg.Badge)
 	}
 
 	uncovered := make([]string, 0, len(suggestions))

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/MustacheCase/zanadir/models"
 	"github.com/MustacheCase/zanadir/output"
 	"github.com/MustacheCase/zanadir/rules"
+	"github.com/MustacheCase/zanadir/score"
 	"github.com/MustacheCase/zanadir/suggester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -560,4 +562,81 @@ func TestFixWriteSurfacesAWriteFailure(t *testing.T) {
 	err := newFixHandler("Secrets Detection").Fix(&config.Config{Dir: dir, Write: true}, &buf)
 
 	assert.Error(t, err)
+}
+
+func TestExecutePassesTheScoreToTheReportAndBadge(t *testing.T) {
+	setup()
+
+	h := NewHandler(mockRuleService, mockScanner, mockSuggester, mockMatcher, mockOutput)
+	badgePath := filepath.Join(t.TempDir(), "badge.json")
+	cfg := config.Config{Dir: "test-dir", Badge: badgePath}
+
+	artifacts := []*models.Artifact{{Name: "artifact1"}}
+	suggestions := []*suggester.CategorySuggestion{{ID: "SCA", Name: "SCA"}, {ID: "Linter", Name: "Linter"}}
+
+	mockScanner.On("Scan", cfg.Dir).Return(artifacts, nil)
+	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{})
+	mockMatcher.On("Match", artifacts, []*rules.Rule{}).Return([]*matcher.Finding{})
+	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions, nil)
+
+	var reported output.Report
+	mockOutput.On("Response", mock.Anything).Run(func(args mock.Arguments) {
+		reported = args.Get(0).(output.Report)
+	}).Return(nil)
+
+	assert.NoError(t, h.Execute(&cfg))
+
+	total := len(models.CategoryTitles)
+	assert.Equal(t, score.Score{Covered: total - 2, Total: total}, reported.Score)
+
+	data, err := os.ReadFile(badgePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), fmt.Sprintf(`"message": "%d/%d"`, total-2, total))
+}
+
+func TestExecuteSurfacesABadgeWriteFailure(t *testing.T) {
+	setup()
+
+	h := NewHandler(mockRuleService, mockScanner, mockSuggester, mockMatcher, mockOutput)
+	cfg := config.Config{Dir: "test-dir", Badge: filepath.Join(t.TempDir(), "no-such-dir", "badge.json")}
+
+	mockScanner.On("Scan", cfg.Dir).Return([]*models.Artifact{}, nil)
+	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{})
+	mockMatcher.On("Match", mock.Anything, mock.Anything).Return([]*matcher.Finding{})
+	mockSuggester.On("FindSuggestions", mock.Anything).Return([]*suggester.CategorySuggestion{}, nil)
+	mockOutput.On("Response", mock.Anything).Return(nil)
+
+	err := h.Execute(&cfg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write badge")
+}
+
+// A baseline records that a gap is accepted, not closed, so it must not move
+// the score: a badge that turned green on a committed file would measure
+// nothing.
+func TestBaselineDoesNotChangeTheScore(t *testing.T) {
+	setup()
+
+	h := NewHandler(mockRuleService, mockScanner, mockSuggester, mockMatcher, mockOutput)
+	path := filepath.Join(t.TempDir(), "baseline.yaml")
+	assert.NoError(t, baseline.Write(path, []string{"SCA"}))
+
+	cfg := config.Config{Dir: "test-dir", Enforce: true, Baseline: path}
+	suggestions := []*suggester.CategorySuggestion{{ID: "SCA", Name: "SCA"}}
+
+	mockScanner.On("Scan", cfg.Dir).Return([]*models.Artifact{}, nil)
+	mockRuleService.On("GetCategoryRules", mock.Anything).Return([]*rules.Rule{})
+	mockMatcher.On("Match", mock.Anything, mock.Anything).Return([]*matcher.Finding{})
+	mockSuggester.On("FindSuggestions", mock.Anything).Return(suggestions, nil)
+
+	var reported output.Report
+	mockOutput.On("Response", mock.Anything).Run(func(args mock.Arguments) {
+		reported = args.Get(0).(output.Report)
+	}).Return(nil)
+
+	assert.NoError(t, h.Execute(&cfg))
+
+	total := len(models.CategoryTitles)
+	assert.Equal(t, score.Score{Covered: total - 1, Total: total}, reported.Score)
 }

--- a/output/output.go
+++ b/output/output.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MustacheCase/zanadir/config"
+	"github.com/MustacheCase/zanadir/score"
 	"github.com/MustacheCase/zanadir/suggester"
 	"github.com/olekukonko/tablewriter"
 )
@@ -18,6 +19,9 @@ type Report struct {
 	Format      string
 	DestPath    string // empty means stdout
 	Anchor      string // repo-relative path SARIF results point at
+	// Score is the coverage summary. A zero score means none was computed and
+	// the headline falls back to a plain count.
+	Score score.Score
 }
 
 type Output interface {
@@ -79,14 +83,23 @@ func paint(enabled bool, style, text string) string {
 	return style + text + ansiReset
 }
 
-func headline(count int) string {
-	if count == 0 {
+// headline summarises the scan, led by the coverage score when there is one.
+func headline(s score.Score, count int) string {
+	prefix := ""
+	if s.Total > 0 {
+		prefix = fmt.Sprintf("Coverage %s - ", s)
+	}
+
+	switch {
+	case count == 0 && prefix == "":
 		return "All categories are covered - no suggestions."
+	case count == 0:
+		return prefix + "all categories are covered."
+	case count == 1:
+		return prefix + "1 category needs attention:"
+	default:
+		return prefix + fmt.Sprintf("%d categories need attention:", count)
 	}
-	if count == 1 {
-		return "1 category needs attention:"
-	}
-	return fmt.Sprintf("%d categories need attention:", count)
 }
 
 // The returned close function is always safe to call.
@@ -128,11 +141,11 @@ func render(w io.Writer, report Report) error {
 		colour := useColour(w)
 
 		if len(suggestions) == 0 {
-			_, err := fmt.Fprintln(w, paint(colour, ansiGreen, headline(0)))
+			_, err := fmt.Fprintln(w, paint(colour, ansiGreen, headline(report.Score, 0)))
 			return err
 		}
 
-		if _, err := fmt.Fprintf(w, "%s\n\n", paint(colour, ansiBold, headline(len(suggestions)))); err != nil {
+		if _, err := fmt.Fprintf(w, "%s\n\n", paint(colour, ansiBold, headline(report.Score, len(suggestions)))); err != nil {
 			return err
 		}
 

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/MustacheCase/zanadir/config"
+	"github.com/MustacheCase/zanadir/score"
 	"github.com/MustacheCase/zanadir/suggester"
 )
 
@@ -200,16 +201,33 @@ func TestResponse_TableLeadsWithACount(t *testing.T) {
 	service := NewOutputService()
 
 	out := captureStdout(func() {
-		if err := service.Response(Report{Suggestions: getSampleSuggestions(), Format: config.OutputTable}); err != nil {
+		report := Report{Suggestions: getSampleSuggestions(), Format: config.OutputTable, Score: score.Score{Covered: 9, Total: 11}}
+		if err := service.Response(report); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	if !strings.HasPrefix(out, "2 categories need attention:") {
-		t.Errorf("expected the count to lead the output, got:\n%s", out)
+	if !strings.HasPrefix(out, "Coverage 9/11 - 2 categories need attention:") {
+		t.Errorf("expected the score and count to lead the output, got:\n%s", out)
 	}
 	if !strings.Contains(strings.ToLower(out), "suggested tools") {
 		t.Errorf("table should still render below the headline:\n%s", out)
+	}
+}
+
+func TestHeadlineLeadsWithTheScoreWhenThereIsOne(t *testing.T) {
+	for _, tc := range []struct {
+		coverage score.Score
+		count    int
+		want     string
+	}{
+		{score.Score{Covered: 9, Total: 11}, 2, "Coverage 9/11 - 2 categories need attention:"},
+		{score.Score{Covered: 10, Total: 11}, 1, "Coverage 10/11 - 1 category needs attention:"},
+		{score.Score{Covered: 11, Total: 11}, 0, "Coverage 11/11 - all categories are covered."},
+	} {
+		if got := headline(tc.coverage, tc.count); got != tc.want {
+			t.Errorf("headline(%v, %d) = %q, want %q", tc.coverage, tc.count, got, tc.want)
+		}
 	}
 }
 
@@ -219,7 +237,7 @@ func TestHeadlineIsGrammatical(t *testing.T) {
 		1: "1 category needs attention:",
 		2: "2 categories need attention:",
 	} {
-		if got := headline(count); got != want {
+		if got := headline(score.Score{}, count); got != want {
 			t.Errorf("headline(%d) = %q, want %q", count, got, want)
 		}
 	}

--- a/score/score.go
+++ b/score/score.go
@@ -1,0 +1,106 @@
+// Package score expresses a scan result as category coverage: how many of the
+// categories that apply to a repository have tooling behind them.
+package score
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/MustacheCase/zanadir/models"
+)
+
+// Score is a repository's category coverage.
+type Score struct {
+	Covered int
+	Total   int
+}
+
+// Of returns the coverage for a scan. Excluded categories leave the
+// denominator, because a repository should not be marked down for a category
+// it has declared irrelevant. Baseline-accepted gaps do not leave it: a
+// baseline records that a gap is tolerated, not that it was closed, and a
+// score that rose when someone committed a file would measure nothing.
+func Of(excluded []string, uncovered int) Score {
+	skip := make(map[string]bool, len(excluded))
+	for _, c := range excluded {
+		if title, ok := models.ResolveCategory(c); ok {
+			skip[string(title)] = true
+		}
+	}
+
+	total := 0
+	for _, title := range models.CategoryTitles {
+		if !skip[string(title)] {
+			total++
+		}
+	}
+
+	covered := total - uncovered
+	if covered < 0 {
+		covered = 0
+	}
+	return Score{Covered: covered, Total: total}
+}
+
+// String renders the score the way it reads on a badge.
+func (s Score) String() string {
+	if s.Total == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%d/%d", s.Covered, s.Total)
+}
+
+// Percent is the covered share, rounded down.
+func (s Score) Percent() int {
+	if s.Total == 0 {
+		return 0
+	}
+	return s.Covered * 100 / s.Total
+}
+
+func (s Score) colour() string {
+	switch {
+	case s.Total == 0:
+		return "lightgrey"
+	case s.Covered == s.Total:
+		return "brightgreen"
+	case s.Percent() >= 80:
+		return "green"
+	case s.Percent() >= 60:
+		return "yellow"
+	case s.Percent() >= 40:
+		return "orange"
+	default:
+		return "red"
+	}
+}
+
+// endpoint is the shields.io endpoint badge schema.
+type endpoint struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Label         string `json:"label"`
+	Message       string `json:"message"`
+	Color         string `json:"color"`
+}
+
+// Write saves the score as a shields.io endpoint badge file, for a README to
+// point at once CI publishes it.
+func Write(path string, s Score) error {
+	data, err := json.MarshalIndent(endpoint{
+		SchemaVersion: 1,
+		Label:         "zanadir",
+		Message:       s.String(),
+		Color:         s.colour(),
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal badge: %w", err)
+	}
+
+	// 0644: the badge is served publicly, and the step that publishes it may
+	// run as a different user than the scan.
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil { //nolint:gosec // operator-supplied path; a badge is world-readable by design
+		return fmt.Errorf("failed to write badge %s: %w", path, err)
+	}
+	return nil
+}

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -1,0 +1,114 @@
+package score
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MustacheCase/zanadir/models"
+)
+
+func TestOfCountsEveryCategory(t *testing.T) {
+	all := len(models.CategoryTitles)
+
+	s := Of(nil, 3)
+	if s.Total != all {
+		t.Errorf("Total = %d, want %d", s.Total, all)
+	}
+	if s.Covered != all-3 {
+		t.Errorf("Covered = %d, want %d", s.Covered, all-3)
+	}
+}
+
+func TestOfDropsExcludedCategoriesFromTheDenominator(t *testing.T) {
+	all := len(models.CategoryTitles)
+
+	// The excluded category is not reported as uncovered either, so a
+	// repository that excludes a gap scores full marks.
+	s := Of([]string{string(models.Coverage)}, 0)
+	if s.Total != all-1 {
+		t.Errorf("Total = %d, want %d", s.Total, all-1)
+	}
+	if s.Percent() != 100 {
+		t.Errorf("Percent = %d, want 100", s.Percent())
+	}
+}
+
+func TestOfIgnoresRepeatedAndUnknownExclusions(t *testing.T) {
+	all := len(models.CategoryTitles)
+
+	s := Of([]string{"coverage", "Coverage", "not a category"}, 0)
+	if s.Total != all-1 {
+		t.Errorf("Total = %d, want %d", s.Total, all-1)
+	}
+}
+
+func TestOfNeverGoesNegative(t *testing.T) {
+	if got := Of(nil, len(models.CategoryTitles)+5).Covered; got != 0 {
+		t.Errorf("Covered = %d, want 0", got)
+	}
+}
+
+func TestScoreWithNothingApplicable(t *testing.T) {
+	s := Of(models.CategoryNames(), 0)
+	if s.Total != 0 {
+		t.Fatalf("Total = %d, want 0", s.Total)
+	}
+	if s.String() != "n/a" {
+		t.Errorf("String() = %q, want %q", s.String(), "n/a")
+	}
+	if s.colour() != "lightgrey" {
+		t.Errorf("colour() = %q, want lightgrey", s.colour())
+	}
+}
+
+func TestColourTracksCoverage(t *testing.T) {
+	for _, tc := range []struct {
+		s    Score
+		want string
+	}{
+		{Score{Covered: 10, Total: 10}, "brightgreen"},
+		{Score{Covered: 8, Total: 10}, "green"},
+		{Score{Covered: 6, Total: 10}, "yellow"},
+		{Score{Covered: 4, Total: 10}, "orange"},
+		{Score{Covered: 3, Total: 10}, "red"},
+		{Score{Covered: 0, Total: 10}, "red"},
+	} {
+		if got := tc.s.colour(); got != tc.want {
+			t.Errorf("%s colour = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestWriteProducesAShieldsEndpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "badge.json")
+
+	if err := Write(path, Score{Covered: 9, Total: 11}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("badge not written: %v", err)
+	}
+
+	var got endpoint
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("badge is not valid JSON: %v", err)
+	}
+
+	want := endpoint{SchemaVersion: 1, Label: "zanadir", Message: "9/11", Color: "green"}
+	if got != want {
+		t.Errorf("badge = %+v, want %+v", got, want)
+	}
+}
+
+func TestWriteReportsAnUnwritablePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-such-dir", "badge.json")
+
+	err := Write(path, Score{Covered: 1, Total: 2})
+	if err == nil {
+		t.Fatal("expected an error for an unwritable destination")
+	}
+}


### PR DESCRIPTION
Roadmap Phase 1, item 1. A scan told you what was missing but never what fraction was covered, so there was nothing to put in a README and nothing to watch improve. The badge is the one feature with a viral loop: it advertises the tool to everyone reading a repo that uses it.

Every scan now reports a coverage score, and `--badge <path>` writes it as a shields.io endpoint file that CI can publish.

```
Coverage 8/11 - 3 categories need attention:
```

```json
{ "schemaVersion": 1, "label": "zanadir", "message": "8/11", "color": "yellow" }
```

### The score definition

Two decisions define the number, both documented in the README:

**Excluded categories leave the denominator.** A repository that declares a category irrelevant with `--excluded-categories` should not be marked down for it.

**Baseline-accepted gaps still count as uncovered.** A baseline records that a gap is tolerated, not that it was closed. A score that rose because someone committed a file would measure nothing. There is a test pinning this.

### Notes

`--badge` deliberately has no `NoOptDefVal`. With one, pflag only accepts `--badge=path`; `--badge path` silently writes to the default location and swallows the path as a positional argument the scan command ignores. That bit me while testing this.

`Report.Score` is optional: a zero value means none was computed and the table headline keeps its plain count, so callers rendering a report without a scan behind it are unaffected.

JSON and SARIF output are unchanged. Adding the score to JSON means turning the top-level array into an object, which is a breaking change worth making on its own.

### Dogfooding

The second commit adds the badge to zanadir's own README and a job that regenerates it on pushes to `main`. It builds from source rather than using `mustachecase/zanadir-action`, which predates `--badge`; it can move to the action after the next release. It runs only on pushes, so a fork's pull request cannot move the badge, and it commits only when the score actually changed.

### Tests

`go test ./...` and `go vet ./...` pass. `golangci-lint` does not run locally — the pinned v2.12.2 is built with go1.24 while go.mod targets 1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)